### PR TITLE
feat: Uygunsuzluk modülüne Anlık Aksiyon (Düzeltme) kaydı

### DIFF
--- a/app/Http/Controllers/ProblemController.php
+++ b/app/Http/Controllers/ProblemController.php
@@ -71,6 +71,7 @@ class ProblemController extends Controller
             'risk:id,code,title',
             'customerComplaint:id,code,title',
             'problemSourceType:id,name',
+            'immediateActionBy:id,name',
         ]);
 
         return Inertia::render('Modules/Problem/ShowPage', [

--- a/app/Http/Controllers/ProblemWorkflowController.php
+++ b/app/Http/Controllers/ProblemWorkflowController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\RecordImmediateActionRequest;
 use App\Models\Problem;
 use App\Services\Problem\ProblemWorkflowService;
 use RuntimeException;
@@ -10,6 +11,14 @@ class ProblemWorkflowController extends Controller
 {
     public function __construct(private readonly ProblemWorkflowService $problemWorkflowService)
     {
+    }
+
+    public function recordImmediateAction(RecordImmediateActionRequest $request, Problem $problem)
+    {
+        return $this->runWorkflowAction(
+            fn () => $this->problemWorkflowService->recordImmediateAction($problem, $request->validated('immediate_action'), auth()->user()),
+            'messages.problem.immediateActionRecorded',
+        );
     }
 
     public function markUnderReview(Problem $problem)

--- a/app/Http/Requests/RecordImmediateActionRequest.php
+++ b/app/Http/Requests/RecordImmediateActionRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RecordImmediateActionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return auth()->check();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'immediate_action' => 'required|string',
+        ];
+    }
+}

--- a/app/Models/Problem.php
+++ b/app/Models/Problem.php
@@ -21,6 +21,9 @@ class Problem extends Model
         'customer_complaint_id',
         'title',
         'description',
+        'immediate_action',
+        'immediate_action_at',
+        'immediate_action_by_id',
         'problem_source_type_id',
         'severity',
         'status',
@@ -35,6 +38,7 @@ class Problem extends Model
         'status' => ProblemStatus::class,
         'detected_date' => 'date',
         'closed_at' => 'datetime',
+        'immediate_action_at' => 'datetime',
     ];
 
     protected static function booted(): void
@@ -84,6 +88,11 @@ class Problem extends Model
     public function detectedBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'detected_by_id');
+    }
+
+    public function immediateActionBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'immediate_action_by_id');
     }
 
     public function department(): BelongsTo

--- a/app/Services/Problem/ProblemWorkflowService.php
+++ b/app/Services/Problem/ProblemWorkflowService.php
@@ -25,6 +25,24 @@ class ProblemWorkflowService
         return $problem;
     }
 
+    /**
+     * The "correction" — a containment action taken right when the
+     * nonconformity is detected, independent of and prior to any root-cause
+     * analysis/CAPA. Not status-gated: it can be recorded or amended at any
+     * point in the problem's lifecycle since it documents what actually
+     * happened, not a workflow transition.
+     */
+    public function recordImmediateAction(Problem $problem, string $immediateAction, User $author): Problem
+    {
+        $problem->update([
+            'immediate_action' => $immediateAction,
+            'immediate_action_at' => now(),
+            'immediate_action_by_id' => $author->id,
+        ]);
+
+        return $problem;
+    }
+
     public function markUnderReview(Problem $problem): Problem
     {
         $this->assertStatus($problem, [ProblemStatus::Open]);

--- a/database/migrations/2026_09_10_120000_add_immediate_action_to_problems_table.php
+++ b/database/migrations/2026_09_10_120000_add_immediate_action_to_problems_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('problems', function (Blueprint $table) {
+            $table->text('immediate_action')->nullable()->after('description');
+            $table->timestamp('immediate_action_at')->nullable()->after('immediate_action');
+            $table->foreignId('immediate_action_by_id')->nullable()->after('immediate_action_at')
+                ->constrained('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('problems', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('immediate_action_by_id');
+            $table->dropColumn(['immediate_action', 'immediate_action_at']);
+        });
+    }
+};

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -177,6 +177,7 @@ return [
         'updated' => 'Problem :problem updated.',
         'deleted' => 'Problem :problem deleted.',
         'deletedError' => 'Problem :problem cannot be deleted because it has CAPAs raised against it.',
+        'immediateActionRecorded' => 'Immediate action recorded.',
         'markedUnderReview' => 'Problem marked under review.',
         'closedWithoutCapa' => 'Problem closed without a CAPA.',
         'closed' => 'Problem closed.'

--- a/lang/tr/messages.php
+++ b/lang/tr/messages.php
@@ -178,6 +178,7 @@ return [
         'updated' => ':problem kodlu uygunsuzluk kaydı güncellendi.',
         'deleted' => ':problem kodlu uygunsuzluk kaydı silindi.',
         'deletedError' => ':problem kodlu uygunsuzluk kaydı silinemez çünkü üzerinde açılmış DÖF kayıtları var.',
+        'immediateActionRecorded' => 'Anlık aksiyon kaydedildi.',
         'markedUnderReview' => 'Uygunsuzluk inceleme durumuna alındı.',
         'closedWithoutCapa' => 'Uygunsuzluk DÖF gerektirmeden kapatıldı.',
         'closed' => 'Uygunsuzluk kapatıldı.'

--- a/resources/js/Pages/Modules/Problem/ShowPage.vue
+++ b/resources/js/Pages/Modules/Problem/ShowPage.vue
@@ -12,6 +12,7 @@ import InputGroup from "@/Components/Form/InputGroup.vue"
 import TextInput from "@/Components/Form/TextInput.vue"
 import TextAreaInput from "@/Components/Form/TextAreaInput.vue"
 import SelectInput from "@/Components/Form/SelectInput.vue"
+import HelpButton from "@/Components/Help/HelpButton.vue"
 
 // Multi-lang
 import Translates from "./translates"
@@ -71,6 +72,33 @@ const capaStatusLabels = {
 }
 
 const formatDate = (value) => value ? new Date(value).toLocaleDateString('tr-TR') : '-'
+const formatDateTime = (value) => value ? new Date(value).toLocaleString('tr-TR') : '-'
+
+/* ---------- Immediate Action ---------- */
+const showImmediateActionModal = ref(false)
+const immediateActionForm = useForm({
+    immediate_action: props.problem.immediate_action ?? "",
+})
+const immediateActionRules = ref({
+    immediate_action: {required: helpers.withMessage(t('message.validation.required'), required)},
+})
+const immediateActionV$ = useVuelidate(immediateActionRules, immediateActionForm)
+
+const openImmediateAction = () => {
+    immediateActionForm.immediate_action = props.problem.immediate_action ?? "";
+    immediateActionV$.value.$reset();
+    showImmediateActionModal.value = true;
+}
+
+const submitImmediateAction = async () => {
+    const isValidated = await immediateActionV$.value.$validate()
+    if (!isValidated) return
+
+    immediateActionForm.post(route('problem.immediate-action', props.problem.id), {
+        onSuccess: () => showImmediateActionModal.value = false,
+        preserveScroll: true,
+    })
+}
 
 /* ---------- Workflow ---------- */
 const markUnderReview = () => {
@@ -125,6 +153,10 @@ const submitRaiseCapa = async () => {
 <template>
     <app-layout :title="tm('title.showPage.title') + ' — ' + problem.code" :sub-title="tm('title.showPage.subTitle')">
         <template #actionArea>
+            <help-button title="Uygunsuzluk Detayı — Nasıl Çalışır?" subtitle="Anlık aksiyon, DÖF ilişkisi ve durum akışını buradan yönetin">
+                <p><strong>Anlık Aksiyon (Düzeltme):</strong> Uygunsuzluk tespit edildiği anda, kök neden araştırması beklenmeden alınan ilk müdahaledir (örn. "etkilenen parti karantinaya alındı"). Bu, kök nedeni ortadan kaldırmaya yönelik DÖF'ten (Düzeltici/Önleyici Faaliyet) farklıdır ve durum akışından bağımsız olarak her an kaydedilebilir/güncellenebilir.</p>
+                <p><strong>Durum akışı:</strong> Açık → (İncelemeye Al) → İnceleniyor → (DÖF Aç) → DÖF Açıldı → (tüm bağlı DÖF'ler kapandığında Kapat) → Kapatıldı. Kök neden araştırması gerekmiyorsa "DÖF Gerektirmeden Kapat" ile doğrudan kapatılabilir.</p>
+            </help-button>
             <simple-button type="route" :link="route('problem.index')">
                 <font-awesome-icon icon="fa-solid fa-left-long" class="mr-2"/>
                 <span v-text="t('action.goBack')"/>
@@ -165,6 +197,10 @@ const submitRaiseCapa = async () => {
                     </div>
                 </div>
                 <div class="flex gap-2 flex-wrap">
+                    <simple-button color="red" @click="openImmediateAction">
+                        <font-awesome-icon icon="bolt" class="mr-2"/>
+                        <span v-text="problem.immediate_action ? tm('action.editImmediateAction') : tm('action.recordImmediateAction')"/>
+                    </simple-button>
                     <simple-button v-if="problem.status === 'open'" color="blue" @click="markUnderReview">
                         <span v-text="tm('action.markUnderReview')"/>
                     </simple-button>
@@ -194,6 +230,12 @@ const submitRaiseCapa = async () => {
             <div class="mt-4 text-sm">
                 <span class="text-slate-400 block" v-text="tm('term.description')"/>
                 <p>{{ problem.description }}</p>
+            </div>
+
+            <div v-if="problem.immediate_action" class="mt-4 text-sm bg-rose-50 dark:bg-rose-950 rounded p-3">
+                <span class="text-rose-500 block" v-text="tm('term.immediateAction')"/>
+                <p>{{ problem.immediate_action }}</p>
+                <p class="text-xs text-slate-400 mt-1">{{ problem.immediate_action_by?.name ?? '-' }} — {{ formatDateTime(problem.immediate_action_at) }}</p>
             </div>
         </div>
 
@@ -231,6 +273,22 @@ const submitRaiseCapa = async () => {
                 </tbody>
             </table>
         </div>
+
+        <!--Immediate Action Modal-->
+        <teleport to="body">
+            <Modal v-model="showImmediateActionModal" :header="tm('action.recordImmediateAction')" closeable close-button max-width="2xl">
+                <Form full-size>
+                    <FormSection bg-less>
+                        <input-group class="col-span-6" labelFor="immediate_action" :label="tm('term.immediateAction')" :errors="immediateActionV$.immediate_action.$errors">
+                            <text-area-input v-model="immediateActionForm.immediate_action"/>
+                        </input-group>
+                    </FormSection>
+                </Form>
+                <template #footer>
+                    <SimpleButton :label="tm('action.recordImmediateAction')" color="red" @click="submitImmediateAction" :loading="immediateActionForm.processing"/>
+                </template>
+            </Modal>
+        </teleport>
 
         <!--Raise CAPA Modal-->
         <teleport to="body">

--- a/resources/js/Pages/Modules/Problem/translates/en.json
+++ b/resources/js/Pages/Modules/Problem/translates/en.json
@@ -29,6 +29,7 @@
         "detectedDate": "Detected Date",
         "closedAt": "Closed At",
         "capaCount": "CAPAs",
+        "immediateAction": "Immediate Action (Correction)",
         "problemSeverity": {
             "low": "Low",
             "medium": "Medium",
@@ -45,6 +46,8 @@
     },
     "action": {
         "viewDetails": "Details / Manage",
+        "recordImmediateAction": "Record Immediate Action",
+        "editImmediateAction": "Edit Immediate Action",
         "markUnderReview": "Mark Under Review",
         "raiseCapa": "Raise CAPA",
         "closeWithoutCapa": "Close Without CAPA",

--- a/resources/js/Pages/Modules/Problem/translates/tr.json
+++ b/resources/js/Pages/Modules/Problem/translates/tr.json
@@ -29,6 +29,7 @@
         "detectedDate": "Tespit Tarihi",
         "closedAt": "Kapanış Tarihi",
         "capaCount": "DÖF",
+        "immediateAction": "Anlık Aksiyon (Düzeltme)",
         "problemSeverity": {
             "low": "Düşük",
             "medium": "Orta",
@@ -45,6 +46,8 @@
     },
     "action": {
         "viewDetails": "Detay / Yönet",
+        "recordImmediateAction": "Anlık Aksiyon Kaydet",
+        "editImmediateAction": "Anlık Aksiyonu Düzenle",
         "markUnderReview": "İncelemeye Al",
         "raiseCapa": "DÖF Aç",
         "closeWithoutCapa": "DÖF Gerektirmeden Kapat",

--- a/resources/js/actions/App/Http/Controllers/ProblemController.ts
+++ b/resources/js/actions/App/Http/Controllers/ProblemController.ts
@@ -380,7 +380,7 @@ show.head = (args: { problem: number | { id: number } } | [problem: number | { i
     show.form = showForm
 /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
 export const edit = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -395,7 +395,7 @@ edit.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
 edit.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -428,7 +428,7 @@ edit.url = (args: { problem: number | { id: number } } | [problem: number | { id
 
 /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
 edit.get = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -437,7 +437,7 @@ edit.get = (args: { problem: number | { id: number } } | [problem: number | { id
 })
 /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
 edit.head = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -447,7 +447,7 @@ edit.head = (args: { problem: number | { id: number } } | [problem: number | { i
 
     /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
     const editForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -457,7 +457,7 @@ edit.head = (args: { problem: number | { id: number } } | [problem: number | { i
 
             /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
         editForm.get = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -466,7 +466,7 @@ edit.head = (args: { problem: number | { id: number } } | [problem: number | { i
         })
             /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
         editForm.head = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -482,7 +482,7 @@ edit.head = (args: { problem: number | { id: number } } | [problem: number | { i
     edit.form = editForm
 /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
 export const update = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -497,7 +497,7 @@ update.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
 update.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -530,7 +530,7 @@ update.url = (args: { problem: number | { id: number } } | [problem: number | { 
 
 /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
 update.put = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -539,7 +539,7 @@ update.put = (args: { problem: number | { id: number } } | [problem: number | { 
 })
 /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
 update.patch = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -549,7 +549,7 @@ update.patch = (args: { problem: number | { id: number } } | [problem: number | 
 
     /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
     const updateForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -564,7 +564,7 @@ update.patch = (args: { problem: number | { id: number } } | [problem: number | 
 
             /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
         updateForm.put = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -578,7 +578,7 @@ update.patch = (args: { problem: number | { id: number } } | [problem: number | 
         })
             /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
         updateForm.patch = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -594,7 +594,7 @@ update.patch = (args: { problem: number | { id: number } } | [problem: number | 
     update.form = updateForm
 /**
 * @see \App\Http\Controllers\ProblemController::destroy
- * @see app/Http/Controllers/ProblemController.php:96
+ * @see app/Http/Controllers/ProblemController.php:97
  * @route '/problem/{problem}'
  */
 export const destroy = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -609,7 +609,7 @@ destroy.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemController::destroy
- * @see app/Http/Controllers/ProblemController.php:96
+ * @see app/Http/Controllers/ProblemController.php:97
  * @route '/problem/{problem}'
  */
 destroy.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -642,7 +642,7 @@ destroy.url = (args: { problem: number | { id: number } } | [problem: number | {
 
 /**
 * @see \App\Http\Controllers\ProblemController::destroy
- * @see app/Http/Controllers/ProblemController.php:96
+ * @see app/Http/Controllers/ProblemController.php:97
  * @route '/problem/{problem}'
  */
 destroy.delete = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -652,7 +652,7 @@ destroy.delete = (args: { problem: number | { id: number } } | [problem: number 
 
     /**
 * @see \App\Http\Controllers\ProblemController::destroy
- * @see app/Http/Controllers/ProblemController.php:96
+ * @see app/Http/Controllers/ProblemController.php:97
  * @route '/problem/{problem}'
  */
     const destroyForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -667,7 +667,7 @@ destroy.delete = (args: { problem: number | { id: number } } | [problem: number 
 
             /**
 * @see \App\Http\Controllers\ProblemController::destroy
- * @see app/Http/Controllers/ProblemController.php:96
+ * @see app/Http/Controllers/ProblemController.php:97
  * @route '/problem/{problem}'
  */
         destroyForm.delete = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({

--- a/resources/js/actions/App/Http/Controllers/ProblemWorkflowController.ts
+++ b/resources/js/actions/App/Http/Controllers/ProblemWorkflowController.ts
@@ -1,7 +1,86 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../wayfinder'
 /**
+* @see \App\Http\Controllers\ProblemWorkflowController::recordImmediateAction
+ * @see app/Http/Controllers/ProblemWorkflowController.php:16
+ * @route '/problem/{problem}/immediate-action'
+ */
+export const recordImmediateAction = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: recordImmediateAction.url(args, options),
+    method: 'post',
+})
+
+recordImmediateAction.definition = {
+    methods: ["post"],
+    url: '/problem/{problem}/immediate-action',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\ProblemWorkflowController::recordImmediateAction
+ * @see app/Http/Controllers/ProblemWorkflowController.php:16
+ * @route '/problem/{problem}/immediate-action'
+ */
+recordImmediateAction.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { problem: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { problem: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    problem: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        problem: typeof args.problem === 'object'
+                ? args.problem.id
+                : args.problem,
+                }
+
+    return recordImmediateAction.definition.url
+            .replace('{problem}', parsedArgs.problem.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\ProblemWorkflowController::recordImmediateAction
+ * @see app/Http/Controllers/ProblemWorkflowController.php:16
+ * @route '/problem/{problem}/immediate-action'
+ */
+recordImmediateAction.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: recordImmediateAction.url(args, options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Http\Controllers\ProblemWorkflowController::recordImmediateAction
+ * @see app/Http/Controllers/ProblemWorkflowController.php:16
+ * @route '/problem/{problem}/immediate-action'
+ */
+    const recordImmediateActionForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: recordImmediateAction.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\ProblemWorkflowController::recordImmediateAction
+ * @see app/Http/Controllers/ProblemWorkflowController.php:16
+ * @route '/problem/{problem}/immediate-action'
+ */
+        recordImmediateActionForm.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: recordImmediateAction.url(args, options),
+            method: 'post',
+        })
+    
+    recordImmediateAction.form = recordImmediateActionForm
+/**
 * @see \App\Http\Controllers\ProblemWorkflowController::markUnderReview
- * @see app/Http/Controllers/ProblemWorkflowController.php:15
+ * @see app/Http/Controllers/ProblemWorkflowController.php:24
  * @route '/problem/{problem}/mark-under-review'
  */
 export const markUnderReview = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -16,7 +95,7 @@ markUnderReview.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::markUnderReview
- * @see app/Http/Controllers/ProblemWorkflowController.php:15
+ * @see app/Http/Controllers/ProblemWorkflowController.php:24
  * @route '/problem/{problem}/mark-under-review'
  */
 markUnderReview.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -49,7 +128,7 @@ markUnderReview.url = (args: { problem: number | { id: number } } | [problem: nu
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::markUnderReview
- * @see app/Http/Controllers/ProblemWorkflowController.php:15
+ * @see app/Http/Controllers/ProblemWorkflowController.php:24
  * @route '/problem/{problem}/mark-under-review'
  */
 markUnderReview.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -59,7 +138,7 @@ markUnderReview.post = (args: { problem: number | { id: number } } | [problem: n
 
     /**
 * @see \App\Http\Controllers\ProblemWorkflowController::markUnderReview
- * @see app/Http/Controllers/ProblemWorkflowController.php:15
+ * @see app/Http/Controllers/ProblemWorkflowController.php:24
  * @route '/problem/{problem}/mark-under-review'
  */
     const markUnderReviewForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -69,7 +148,7 @@ markUnderReview.post = (args: { problem: number | { id: number } } | [problem: n
 
             /**
 * @see \App\Http\Controllers\ProblemWorkflowController::markUnderReview
- * @see app/Http/Controllers/ProblemWorkflowController.php:15
+ * @see app/Http/Controllers/ProblemWorkflowController.php:24
  * @route '/problem/{problem}/mark-under-review'
  */
         markUnderReviewForm.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -80,7 +159,7 @@ markUnderReview.post = (args: { problem: number | { id: number } } | [problem: n
     markUnderReview.form = markUnderReviewForm
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::closeWithoutCapa
- * @see app/Http/Controllers/ProblemWorkflowController.php:23
+ * @see app/Http/Controllers/ProblemWorkflowController.php:32
  * @route '/problem/{problem}/close-without-capa'
  */
 export const closeWithoutCapa = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -95,7 +174,7 @@ closeWithoutCapa.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::closeWithoutCapa
- * @see app/Http/Controllers/ProblemWorkflowController.php:23
+ * @see app/Http/Controllers/ProblemWorkflowController.php:32
  * @route '/problem/{problem}/close-without-capa'
  */
 closeWithoutCapa.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -128,7 +207,7 @@ closeWithoutCapa.url = (args: { problem: number | { id: number } } | [problem: n
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::closeWithoutCapa
- * @see app/Http/Controllers/ProblemWorkflowController.php:23
+ * @see app/Http/Controllers/ProblemWorkflowController.php:32
  * @route '/problem/{problem}/close-without-capa'
  */
 closeWithoutCapa.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -138,7 +217,7 @@ closeWithoutCapa.post = (args: { problem: number | { id: number } } | [problem: 
 
     /**
 * @see \App\Http\Controllers\ProblemWorkflowController::closeWithoutCapa
- * @see app/Http/Controllers/ProblemWorkflowController.php:23
+ * @see app/Http/Controllers/ProblemWorkflowController.php:32
  * @route '/problem/{problem}/close-without-capa'
  */
     const closeWithoutCapaForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -148,7 +227,7 @@ closeWithoutCapa.post = (args: { problem: number | { id: number } } | [problem: 
 
             /**
 * @see \App\Http\Controllers\ProblemWorkflowController::closeWithoutCapa
- * @see app/Http/Controllers/ProblemWorkflowController.php:23
+ * @see app/Http/Controllers/ProblemWorkflowController.php:32
  * @route '/problem/{problem}/close-without-capa'
  */
         closeWithoutCapaForm.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -159,7 +238,7 @@ closeWithoutCapa.post = (args: { problem: number | { id: number } } | [problem: 
     closeWithoutCapa.form = closeWithoutCapaForm
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::close
- * @see app/Http/Controllers/ProblemWorkflowController.php:31
+ * @see app/Http/Controllers/ProblemWorkflowController.php:40
  * @route '/problem/{problem}/close'
  */
 export const close = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -174,7 +253,7 @@ close.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::close
- * @see app/Http/Controllers/ProblemWorkflowController.php:31
+ * @see app/Http/Controllers/ProblemWorkflowController.php:40
  * @route '/problem/{problem}/close'
  */
 close.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -207,7 +286,7 @@ close.url = (args: { problem: number | { id: number } } | [problem: number | { i
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::close
- * @see app/Http/Controllers/ProblemWorkflowController.php:31
+ * @see app/Http/Controllers/ProblemWorkflowController.php:40
  * @route '/problem/{problem}/close'
  */
 close.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -217,7 +296,7 @@ close.post = (args: { problem: number | { id: number } } | [problem: number | { 
 
     /**
 * @see \App\Http\Controllers\ProblemWorkflowController::close
- * @see app/Http/Controllers/ProblemWorkflowController.php:31
+ * @see app/Http/Controllers/ProblemWorkflowController.php:40
  * @route '/problem/{problem}/close'
  */
     const closeForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -227,7 +306,7 @@ close.post = (args: { problem: number | { id: number } } | [problem: number | { 
 
             /**
 * @see \App\Http\Controllers\ProblemWorkflowController::close
- * @see app/Http/Controllers/ProblemWorkflowController.php:31
+ * @see app/Http/Controllers/ProblemWorkflowController.php:40
  * @route '/problem/{problem}/close'
  */
         closeForm.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -236,6 +315,6 @@ close.post = (args: { problem: number | { id: number } } | [problem: number | { 
         })
     
     close.form = closeForm
-const ProblemWorkflowController = { markUnderReview, closeWithoutCapa, close }
+const ProblemWorkflowController = { recordImmediateAction, markUnderReview, closeWithoutCapa, close }
 
 export default ProblemWorkflowController

--- a/resources/js/routes/index.ts
+++ b/resources/js/routes/index.ts
@@ -282,7 +282,7 @@ dashboard.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     
     dashboard.form = dashboardForm
 /**
- * @see routes/web.php:357
+ * @see routes/web.php:358
  * @route '/test'
  */
 export const route = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -296,7 +296,7 @@ route.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:357
+ * @see routes/web.php:358
  * @route '/test'
  */
 route.url = (options?: RouteQueryOptions) => {
@@ -304,7 +304,7 @@ route.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:357
+ * @see routes/web.php:358
  * @route '/test'
  */
 route.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -312,7 +312,7 @@ route.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:357
+ * @see routes/web.php:358
  * @route '/test'
  */
 route.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -321,7 +321,7 @@ route.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:357
+ * @see routes/web.php:358
  * @route '/test'
  */
     const routeForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -330,7 +330,7 @@ route.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:357
+ * @see routes/web.php:358
  * @route '/test'
  */
         routeForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -338,7 +338,7 @@ route.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:357
+ * @see routes/web.php:358
  * @route '/test'
  */
         routeForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/resources/js/routes/problem/index.ts
+++ b/resources/js/routes/problem/index.ts
@@ -369,7 +369,7 @@ show.head = (args: { problem: number | { id: number } } | [problem: number | { i
     show.form = showForm
 /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
 export const edit = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -384,7 +384,7 @@ edit.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
 edit.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -417,7 +417,7 @@ edit.url = (args: { problem: number | { id: number } } | [problem: number | { id
 
 /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
 edit.get = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -426,7 +426,7 @@ edit.get = (args: { problem: number | { id: number } } | [problem: number | { id
 })
 /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
 edit.head = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -436,7 +436,7 @@ edit.head = (args: { problem: number | { id: number } } | [problem: number | { i
 
     /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
     const editForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -446,7 +446,7 @@ edit.head = (args: { problem: number | { id: number } } | [problem: number | { i
 
             /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
         editForm.get = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -455,7 +455,7 @@ edit.head = (args: { problem: number | { id: number } } | [problem: number | { i
         })
             /**
 * @see \App\Http\Controllers\ProblemController::edit
- * @see app/Http/Controllers/ProblemController.php:82
+ * @see app/Http/Controllers/ProblemController.php:83
  * @route '/problem/{problem}/edit'
  */
         editForm.head = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -471,7 +471,7 @@ edit.head = (args: { problem: number | { id: number } } | [problem: number | { i
     edit.form = editForm
 /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
 export const update = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -486,7 +486,7 @@ update.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
 update.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -519,7 +519,7 @@ update.url = (args: { problem: number | { id: number } } | [problem: number | { 
 
 /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
 update.put = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -528,7 +528,7 @@ update.put = (args: { problem: number | { id: number } } | [problem: number | { 
 })
 /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
 update.patch = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -538,7 +538,7 @@ update.patch = (args: { problem: number | { id: number } } | [problem: number | 
 
     /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
     const updateForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -553,7 +553,7 @@ update.patch = (args: { problem: number | { id: number } } | [problem: number | 
 
             /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
         updateForm.put = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -567,7 +567,7 @@ update.patch = (args: { problem: number | { id: number } } | [problem: number | 
         })
             /**
 * @see \App\Http\Controllers\ProblemController::update
- * @see app/Http/Controllers/ProblemController.php:87
+ * @see app/Http/Controllers/ProblemController.php:88
  * @route '/problem/{problem}'
  */
         updateForm.patch = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -583,7 +583,7 @@ update.patch = (args: { problem: number | { id: number } } | [problem: number | 
     update.form = updateForm
 /**
 * @see \App\Http\Controllers\ProblemController::destroy
- * @see app/Http/Controllers/ProblemController.php:96
+ * @see app/Http/Controllers/ProblemController.php:97
  * @route '/problem/{problem}'
  */
 export const destroy = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -598,7 +598,7 @@ destroy.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemController::destroy
- * @see app/Http/Controllers/ProblemController.php:96
+ * @see app/Http/Controllers/ProblemController.php:97
  * @route '/problem/{problem}'
  */
 destroy.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -631,7 +631,7 @@ destroy.url = (args: { problem: number | { id: number } } | [problem: number | {
 
 /**
 * @see \App\Http\Controllers\ProblemController::destroy
- * @see app/Http/Controllers/ProblemController.php:96
+ * @see app/Http/Controllers/ProblemController.php:97
  * @route '/problem/{problem}'
  */
 destroy.delete = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -641,7 +641,7 @@ destroy.delete = (args: { problem: number | { id: number } } | [problem: number 
 
     /**
 * @see \App\Http\Controllers\ProblemController::destroy
- * @see app/Http/Controllers/ProblemController.php:96
+ * @see app/Http/Controllers/ProblemController.php:97
  * @route '/problem/{problem}'
  */
     const destroyForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -656,7 +656,7 @@ destroy.delete = (args: { problem: number | { id: number } } | [problem: number 
 
             /**
 * @see \App\Http\Controllers\ProblemController::destroy
- * @see app/Http/Controllers/ProblemController.php:96
+ * @see app/Http/Controllers/ProblemController.php:97
  * @route '/problem/{problem}'
  */
         destroyForm.delete = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -671,8 +671,87 @@ destroy.delete = (args: { problem: number | { id: number } } | [problem: number 
     
     destroy.form = destroyForm
 /**
+* @see \App\Http\Controllers\ProblemWorkflowController::immediateAction
+ * @see app/Http/Controllers/ProblemWorkflowController.php:16
+ * @route '/problem/{problem}/immediate-action'
+ */
+export const immediateAction = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: immediateAction.url(args, options),
+    method: 'post',
+})
+
+immediateAction.definition = {
+    methods: ["post"],
+    url: '/problem/{problem}/immediate-action',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\ProblemWorkflowController::immediateAction
+ * @see app/Http/Controllers/ProblemWorkflowController.php:16
+ * @route '/problem/{problem}/immediate-action'
+ */
+immediateAction.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { problem: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { problem: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    problem: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        problem: typeof args.problem === 'object'
+                ? args.problem.id
+                : args.problem,
+                }
+
+    return immediateAction.definition.url
+            .replace('{problem}', parsedArgs.problem.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\ProblemWorkflowController::immediateAction
+ * @see app/Http/Controllers/ProblemWorkflowController.php:16
+ * @route '/problem/{problem}/immediate-action'
+ */
+immediateAction.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: immediateAction.url(args, options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Http\Controllers\ProblemWorkflowController::immediateAction
+ * @see app/Http/Controllers/ProblemWorkflowController.php:16
+ * @route '/problem/{problem}/immediate-action'
+ */
+    const immediateActionForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: immediateAction.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\ProblemWorkflowController::immediateAction
+ * @see app/Http/Controllers/ProblemWorkflowController.php:16
+ * @route '/problem/{problem}/immediate-action'
+ */
+        immediateActionForm.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: immediateAction.url(args, options),
+            method: 'post',
+        })
+    
+    immediateAction.form = immediateActionForm
+/**
 * @see \App\Http\Controllers\ProblemWorkflowController::markUnderReview
- * @see app/Http/Controllers/ProblemWorkflowController.php:15
+ * @see app/Http/Controllers/ProblemWorkflowController.php:24
  * @route '/problem/{problem}/mark-under-review'
  */
 export const markUnderReview = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -687,7 +766,7 @@ markUnderReview.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::markUnderReview
- * @see app/Http/Controllers/ProblemWorkflowController.php:15
+ * @see app/Http/Controllers/ProblemWorkflowController.php:24
  * @route '/problem/{problem}/mark-under-review'
  */
 markUnderReview.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -720,7 +799,7 @@ markUnderReview.url = (args: { problem: number | { id: number } } | [problem: nu
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::markUnderReview
- * @see app/Http/Controllers/ProblemWorkflowController.php:15
+ * @see app/Http/Controllers/ProblemWorkflowController.php:24
  * @route '/problem/{problem}/mark-under-review'
  */
 markUnderReview.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -730,7 +809,7 @@ markUnderReview.post = (args: { problem: number | { id: number } } | [problem: n
 
     /**
 * @see \App\Http\Controllers\ProblemWorkflowController::markUnderReview
- * @see app/Http/Controllers/ProblemWorkflowController.php:15
+ * @see app/Http/Controllers/ProblemWorkflowController.php:24
  * @route '/problem/{problem}/mark-under-review'
  */
     const markUnderReviewForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -740,7 +819,7 @@ markUnderReview.post = (args: { problem: number | { id: number } } | [problem: n
 
             /**
 * @see \App\Http\Controllers\ProblemWorkflowController::markUnderReview
- * @see app/Http/Controllers/ProblemWorkflowController.php:15
+ * @see app/Http/Controllers/ProblemWorkflowController.php:24
  * @route '/problem/{problem}/mark-under-review'
  */
         markUnderReviewForm.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -751,7 +830,7 @@ markUnderReview.post = (args: { problem: number | { id: number } } | [problem: n
     markUnderReview.form = markUnderReviewForm
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::closeWithoutCapa
- * @see app/Http/Controllers/ProblemWorkflowController.php:23
+ * @see app/Http/Controllers/ProblemWorkflowController.php:32
  * @route '/problem/{problem}/close-without-capa'
  */
 export const closeWithoutCapa = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -766,7 +845,7 @@ closeWithoutCapa.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::closeWithoutCapa
- * @see app/Http/Controllers/ProblemWorkflowController.php:23
+ * @see app/Http/Controllers/ProblemWorkflowController.php:32
  * @route '/problem/{problem}/close-without-capa'
  */
 closeWithoutCapa.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -799,7 +878,7 @@ closeWithoutCapa.url = (args: { problem: number | { id: number } } | [problem: n
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::closeWithoutCapa
- * @see app/Http/Controllers/ProblemWorkflowController.php:23
+ * @see app/Http/Controllers/ProblemWorkflowController.php:32
  * @route '/problem/{problem}/close-without-capa'
  */
 closeWithoutCapa.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -809,7 +888,7 @@ closeWithoutCapa.post = (args: { problem: number | { id: number } } | [problem: 
 
     /**
 * @see \App\Http\Controllers\ProblemWorkflowController::closeWithoutCapa
- * @see app/Http/Controllers/ProblemWorkflowController.php:23
+ * @see app/Http/Controllers/ProblemWorkflowController.php:32
  * @route '/problem/{problem}/close-without-capa'
  */
     const closeWithoutCapaForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -819,7 +898,7 @@ closeWithoutCapa.post = (args: { problem: number | { id: number } } | [problem: 
 
             /**
 * @see \App\Http\Controllers\ProblemWorkflowController::closeWithoutCapa
- * @see app/Http/Controllers/ProblemWorkflowController.php:23
+ * @see app/Http/Controllers/ProblemWorkflowController.php:32
  * @route '/problem/{problem}/close-without-capa'
  */
         closeWithoutCapaForm.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -830,7 +909,7 @@ closeWithoutCapa.post = (args: { problem: number | { id: number } } | [problem: 
     closeWithoutCapa.form = closeWithoutCapaForm
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::close
- * @see app/Http/Controllers/ProblemWorkflowController.php:31
+ * @see app/Http/Controllers/ProblemWorkflowController.php:40
  * @route '/problem/{problem}/close'
  */
 export const close = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -845,7 +924,7 @@ close.definition = {
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::close
- * @see app/Http/Controllers/ProblemWorkflowController.php:31
+ * @see app/Http/Controllers/ProblemWorkflowController.php:40
  * @route '/problem/{problem}/close'
  */
 close.url = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -878,7 +957,7 @@ close.url = (args: { problem: number | { id: number } } | [problem: number | { i
 
 /**
 * @see \App\Http\Controllers\ProblemWorkflowController::close
- * @see app/Http/Controllers/ProblemWorkflowController.php:31
+ * @see app/Http/Controllers/ProblemWorkflowController.php:40
  * @route '/problem/{problem}/close'
  */
 close.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -888,7 +967,7 @@ close.post = (args: { problem: number | { id: number } } | [problem: number | { 
 
     /**
 * @see \App\Http\Controllers\ProblemWorkflowController::close
- * @see app/Http/Controllers/ProblemWorkflowController.php:31
+ * @see app/Http/Controllers/ProblemWorkflowController.php:40
  * @route '/problem/{problem}/close'
  */
     const closeForm = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -898,7 +977,7 @@ close.post = (args: { problem: number | { id: number } } | [problem: number | { 
 
             /**
 * @see \App\Http\Controllers\ProblemWorkflowController::close
- * @see app/Http/Controllers/ProblemWorkflowController.php:31
+ * @see app/Http/Controllers/ProblemWorkflowController.php:40
  * @route '/problem/{problem}/close'
  */
         closeForm.post = (args: { problem: number | { id: number } } | [problem: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -916,6 +995,7 @@ show: Object.assign(show, show),
 edit: Object.assign(edit, edit),
 update: Object.assign(update, update),
 destroy: Object.assign(destroy, destroy),
+immediateAction: Object.assign(immediateAction, immediateAction),
 markUnderReview: Object.assign(markUnderReview, markUnderReview),
 closeWithoutCapa: Object.assign(closeWithoutCapa, closeWithoutCapa),
 close: Object.assign(close, close),

--- a/routes/web.php
+++ b/routes/web.php
@@ -294,6 +294,7 @@ Route::middleware([
     Route::post('capa/{capa}/reopen', [CapaWorkflowController::class, 'reopen'])->name('capa.reopen');
 
     // Problem (Uygunsuzluk) Workflow
+    Route::post('problem/{problem}/immediate-action', [ProblemWorkflowController::class, 'recordImmediateAction'])->name('problem.immediate-action');
     Route::post('problem/{problem}/mark-under-review', [ProblemWorkflowController::class, 'markUnderReview'])->name('problem.mark-under-review');
     Route::post('problem/{problem}/close-without-capa', [ProblemWorkflowController::class, 'closeWithoutCapa'])->name('problem.close-without-capa');
     Route::post('problem/{problem}/close', [ProblemWorkflowController::class, 'close'])->name('problem.close');

--- a/tests/Feature/ProblemWorkflowTest.php
+++ b/tests/Feature/ProblemWorkflowTest.php
@@ -16,6 +16,45 @@ function makeProblem(User $author): Problem
     ]);
 }
 
+test('an immediate action can be recorded on a problem regardless of status', function () {
+    $author = User::factory()->create();
+    $problem = makeProblem($author);
+
+    $this->actingAs($author)
+        ->post(route('problem.immediate-action', $problem), [
+            'immediate_action' => 'Etkilenen parti karantinaya alındı.',
+        ])
+        ->assertSessionHasNoErrors();
+
+    expect($problem->fresh()->immediate_action)->toBe('Etkilenen parti karantinaya alındı.')
+        ->and($problem->fresh()->immediate_action_by_id)->toBe($author->id)
+        ->and($problem->fresh()->immediate_action_at)->not->toBeNull()
+        ->and($problem->fresh()->status)->toBe(ProblemStatus::Open);
+});
+
+test('recording an immediate action requires a description', function () {
+    $author = User::factory()->create();
+    $problem = makeProblem($author);
+
+    $this->actingAs($author)
+        ->post(route('problem.immediate-action', $problem), [])
+        ->assertSessionHasErrors(['immediate_action']);
+});
+
+test('an immediate action can be amended after it was first recorded', function () {
+    $author = User::factory()->create();
+    $problem = makeProblem($author);
+    $problem->update(['immediate_action' => 'İlk kayıt.', 'immediate_action_at' => now(), 'immediate_action_by_id' => $author->id]);
+
+    $this->actingAs($author)
+        ->post(route('problem.immediate-action', $problem), [
+            'immediate_action' => 'Güncellenmiş kayıt.',
+        ])
+        ->assertSessionHasNoErrors();
+
+    expect($problem->fresh()->immediate_action)->toBe('Güncellenmiş kayıt.');
+});
+
 test('raising a capa against a problem moves it into the capa_raised state', function () {
     $author = User::factory()->create();
     $problem = makeProblem($author);


### PR DESCRIPTION
## Özet

Uzun süredir onaylı, hiç uygulanmamış roadmap kalemi: `problems.immediate_action` / `immediate_action_at` alanları.

ISO 9001'de **"düzeltme" (correction)** ile **"düzeltici faaliyet" (corrective action / DÖF)** ayrı kavramlardır: düzeltme, uygunsuzluk tespit edildiği anda kök neden beklenmeden alınan ilk müdahaledir (örn. "etkilenen parti karantinaya alındı"); DÖF ise kök nedeni ortadan kaldırmaya yöneliktir. Bu PR, uygunsuzluk kayıtlarına bu anlık aksiyonu ayrı bir alan olarak ekliyor.

## Teknik detaylar

- `problems.immediate_action` (metin), `immediate_action_at` (zaman damgası), `immediate_action_by_id` (FK users) eklendi.
- `ProblemWorkflowService::recordImmediateAction()` — **durum bağımsız**: bu bir workflow geçişi değil, ne olduğunu belgeleyen bir kayıt olduğu için uygunsuzluğun yaşam döngüsünün her anında kaydedilebilir/güncellenebilir.
- Uygunsuzluk detay sayfasına "Anlık Aksiyon Kaydet" butonu + modalı eklendi; kayıt varsa buton "Anlık Aksiyonu Düzenle"ye dönüşüyor. Düzeltme/DÖF ayrımını açıklayan bir "Nasıl Çalışır?" yardım paneli de eklendi.

## Test

- 3 yeni test (kayıt, doğrulama, güncelleme). Toplam 334 test, 330 geçti, 4 skip, 0 fail.
- Chrome'da gerçek bir uygunsuzluk kaydı üzerinde uçtan uca doğrulandı: buton modalı açıyor, gönderim doğru kullanıcı/zaman damgasını kaydediyor, kayıt vurgulu bilgi kutusunda doğru render oluyor, buton etiketi güncelleniyor — konsol hatası yok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)