### PR TITLE
feat: Standart (+ Akreditasyon) modülüne yardım paneli ekle

### DIFF
--- a/resources/js/Pages/Modules/Standard/AccreditationsPage.vue
+++ b/resources/js/Pages/Modules/Standard/AccreditationsPage.vue
@@ -14,6 +14,7 @@ import TextInput from "@/Components/Form/TextInput.vue"
 import TextAreaInput from "@/Components/Form/TextAreaInput.vue"
 import SelectInput from "@/Components/Form/SelectInput.vue"
 import FileInput from "@/Components/Form/FileInput.vue"
+import HelpButton from "@/Components/Help/HelpButton.vue"
 
 // Multi-lang
 import Translates from "./translates"
@@ -153,6 +154,10 @@ const handleDelete = (id) => {
 <template>
     <app-layout :title="tm('title.accreditationsPage.title') + ' — ' + standard.name" :sub-title="tm('title.accreditationsPage.subTitle')">
         <template #actionArea>
+            <help-button title="Akreditasyonlar — Nasıl Çalışır?" subtitle="Sertifika durumu ve süre dolumu takibi buradan yönetilir">
+                <p><strong>Akreditasyon Kaydı:</strong> Bir sertifikasyon kuruluşunun bu standarda göre verdiği somut sertifikayı temsil eder — sertifika numarası, kapsamı, veriliş/geçerlilik tarihleri ve isteğe bağlı sertifika dosyası ile birlikte kaydedilir.</p>
+                <p><strong>Durum ile Süre Dolumu bağımsızdır:</strong> "Aktif/Askıya Alınmış/Geri Çekilmiş" durumu elle seçilen bir alandır; "Süresi Doldu" rozeti ise yalnızca geçerlilik tarihine bakılarak otomatik hesaplanır. Yani bir sertifika durumu hâlâ "Aktif" görünse bile geçerlilik tarihi geçmişse "Süresi Doldu" rozeti ayrıca görünür — durumu güncellemek kullanıcının elindedir, sistem otomatik değiştirmez.</p>
+            </help-button>
             <simple-button type="route" :link="route('standard.index')">
                 <font-awesome-icon icon="fa-solid fa-left-long" class="mr-2"/>
                 <span v-text="t('action.goBack')"/>

--- a/resources/js/Pages/Modules/Standard/IndexPage.vue
+++ b/resources/js/Pages/Modules/Standard/IndexPage.vue
@@ -12,6 +12,7 @@ import FormSection from "@/Components/Form/FormSection.vue"
 import InputGroup from "@/Components/Form/InputGroup.vue"
 import TextInput from "@/Components/Form/TextInput.vue"
 import TextAreaInput from "@/Components/Form/TextAreaInput.vue"
+import HelpButton from "@/Components/Help/HelpButton.vue"
 
 // Multi-lang
 import Translates from "./translates"
@@ -99,6 +100,12 @@ const handleDelete = (id) => {
 
 <template>
     <app-layout :title="tm('title.indexPage.title')" :sub-title="tm('title.indexPage.subTitle')">
+        <template #actionArea>
+            <help-button title="Standartlar — Nasıl Çalışır?" subtitle="Standart ile akreditasyon kaydı arasındaki ilişkiyi buradan öğrenin">
+                <p><strong>Standart:</strong> Şirketin uyduğu/uygulamak istediği kalite standardının tanımıdır (ör. ISO 9001, ISO 14001). Kendisi bir sertifika değildir — bir sertifikasyon kuruluşunun bu standarda göre verdiği somut belgeler ayrı bir kayıt olan "akreditasyon"dur.</p>
+                <p><strong>Akreditasyon Sayısı:</strong> Bir standarda bağlı kaç akreditasyon (sertifika) kaydı olduğunu gösterir. Sertifika numarası, geçerlilik tarihleri ve durumu yönetmek için sertifika ikonuna tıklayarak o standardın akreditasyon listesine gidin.</p>
+            </help-button>
+        </template>
         <Table
             :data="tableData"
             :headers="headers"


### PR DESCRIPTION
## Özet
Yardım-paneli yayılım planının bir sonraki adımı: **Standart (+ Akreditasyon)** modülüne iki panel eklendi.

## Kapsam
- `Standard/IndexPage.vue` — standart (ör. ISO 9001) ile akreditasyon kaydı (somut sertifika) arasındaki ilişkiyi açıklıyor.
- `Standard/AccreditationsPage.vue` — akreditasyon kaydının neyi temsil ettiğini ve önemli bir ince ayrımı anlatıyor: elle seçilen "Durum" (Aktif/Askıya Alınmış/Geri Çekilmiş) alanı ile yalnızca geçerlilik tarihine bakılarak otomatik hesaplanan "Süresi Doldu" rozeti birbirinden bağımsızdır — bir kayıt durumu hâlâ "Aktif" görünse bile tarihi geçmişse "Süresi Doldu" rozeti ayrıca görünür.

## Test
- Yalnızca frontend/metin değişikliği; `npm run build` başarılı, Standard (7/7) ve Accreditation (8/8) test grupları geçti.
- Chrome ile uçtan uca doğrulandı: her iki panel de doğru boyut/konumda render ediliyor (bu arada merge edilen Modal düzeltmesini de bu sayfalarda teyit etmiş oldum), konsol hatası yok. Doğrulama için oluşturduğum test kaydı temizlendi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)