### PR TITLE
feat: Eğitim modülüne yardım paneli ekle ve katılımcı yönetimini bağla

### DIFF
--- a/app/Http/Controllers/HumanResources/Education/EducationController.php
+++ b/app/Http/Controllers/HumanResources/Education/EducationController.php
@@ -9,6 +9,7 @@ use App\Models\HumanResources\Education\Education;
 use App\Models\HumanResources\Education\EducationInstructor;
 use App\Models\HumanResources\Education\EducationPlan;
 use App\Models\HumanResources\Education\EducationType;
+use App\Models\HumanResources\Employee\Employee;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -119,6 +120,14 @@ class EducationController extends Controller
                 'participations.user',
                 'media',
             ]),
+            'candidateUsers' => Employee::whereHas('account')
+                ->with('account:id,accountable_id,accountable_type,name')
+                ->get(['id', 'name'])
+                ->map(fn (Employee $employee) => [
+                    'id' => $employee->account->id,
+                    'name' => $employee->account->name ?: $employee->name,
+                ])
+                ->values(),
         ]);
     }
 

--- a/app/Http/Controllers/HumanResources/Education/EducationPlanController.php
+++ b/app/Http/Controllers/HumanResources/Education/EducationPlanController.php
@@ -70,7 +70,7 @@ class EducationPlanController extends Controller
     public function show(EducationPlan $educationPlan)
     {
         return Inertia::render('Modules/HumanResources/EducationPlan/ShowPage', [
-            'data' => $educationPlan,
+            'data' => $educationPlan->load(['educations' => fn ($query) => $query->select('id', 'education_plan_id', 'name', 'planned_date', 'is_completed', 'is_cancelled')]),
         ]);
     }
 

--- a/resources/js/Pages/Modules/HumanResources/Education/ShowPage.vue
+++ b/resources/js/Pages/Modules/HumanResources/Education/ShowPage.vue
@@ -7,12 +7,20 @@ import {router} from "@inertiajs/vue3";
 import SimpleButton from "@/Components/Button/SimpleButton.vue"
 import Alert from "@/Components/Alert/Alert.vue"
 import Badge from "@/Components/Badge/Badge.vue"
+import HelpButton from "@/Components/Help/HelpButton.vue"
+import Modal from "@/Components/Modal/Modal.vue"
+import InputGroup from "@/Components/Form/InputGroup.vue"
+import SelectInput from "@/Components/Form/SelectInput.vue"
 
 // Props
 const props = defineProps({
     data: {
         type: Object,
         default: {}
+    },
+    candidateUsers: {
+        type: Array,
+        default: () => []
     }
 })
 
@@ -20,6 +28,37 @@ const props = defineProps({
 import Translates from "./translates"
 
 const {t, tm} = Translates();
+
+/*Add participant*/
+const showAddParticipantModal = ref(false);
+const newParticipantUserId = ref(null);
+const addParticipant = () => {
+    if (!newParticipantUserId.value) return;
+    router.post(route('education.add-participant', props.data.id), {
+        user_id: newParticipantUserId.value,
+    }, {
+        preserveScroll: true,
+        onSuccess: () => {
+            showAddParticipantModal.value = false;
+            newParticipantUserId.value = null;
+        }
+    })
+}
+
+/*Update participant (attendance / success / score)*/
+const updateParticipant = (participation, changes) => {
+    router.put(route('education.update-participant', [props.data.id, participation.user_id]), {
+        is_attend: participation.is_attend,
+        status: participation.status,
+        score: participation.score,
+        ...changes,
+    }, {preserveScroll: true})
+}
+
+/*Remove participant*/
+const removeParticipant = (participation) => {
+    router.delete(route('education.remove-participant', [props.data.id, participation.user_id]), {preserveScroll: true})
+}
 
 // Status badge colors
 const getStatusColor = (education) => {
@@ -59,6 +98,12 @@ const formatDuration = (minutes) => {
 <template>
     <app-layout :title="tm('title.showPage.title')" :sub-title="props.data.name">
         <template #actionArea>
+            <help-button title="Eğitim Detayı — Nasıl Çalışır?" subtitle="Durum, katılımcı ve eğitmen yönetimi">
+                <p><strong>Durum Rozeti:</strong> Bir eğitim varsayılan olarak "Planlandı" durumundadır. Düzenleme formundaki "Tamamlandı" ve "İptal Edildi" işaretleri birbirinden bağımsızdır — sistem ikisinin aynı anda işaretlenmesini engellemez, rozet önceliği önce iptali, sonra tamamlanmayı gösterir.</p>
+                <p><strong>Katılımcılar:</strong> Her katılımcı için üç ayrı bilgi tutulur: <strong>Katıldı mı</strong> (fiilen eğitime katıldı mı), <strong>Başarılı mı</strong> (eğitimi başarıyla tamamladı mı) ve 0-100 arası <strong>puan</strong>. Bu üçü birbirinden bağımsızdır; birini işaretlemek diğerini otomatik değiştirmez.</p>
+                <p><strong>Eğitmenler:</strong> Eğitmen listesi, kişi bazlı hesap gerektirmeyen ayrı bir "Eğitmen" tanım tablosundan (Modül Ayarları) gelir — katılımcı listesindeki kullanıcı hesaplarından farklıdır.</p>
+            </help-button>
+
             <!--Return to List-->
             <simple-button type="route" :link="route('education.index')" color="gray">
                 <font-awesome-icon icon="arrow-left" class="mr-2"/>
@@ -69,12 +114,6 @@ const formatDuration = (minutes) => {
             <simple-button type="route" :link="route('education.edit', props.data.id)" color="blue">
                 <font-awesome-icon icon="edit" class="mr-2"/>
                 <span v-text="tm('action.editEducation')"/>
-            </simple-button>
-
-            <!--Manage Participants-->
-            <simple-button color="purple">
-                <font-awesome-icon icon="users" class="mr-2"/>
-                <span v-text="tm('action.manageParticipants')"/>
             </simple-button>
         </template>
 
@@ -208,14 +247,14 @@ const formatDuration = (minutes) => {
                 <div class="bg-white dark:bg-slate-800 rounded-lg p-6 shadow">
                     <div class="flex items-center justify-between mb-4">
                         <h3 class="text-lg font-semibold">{{ tm('term.participants') }}</h3>
-                        <simple-button color="green" size="sm">
+                        <simple-button color="green" size="sm" @click="showAddParticipantModal = true">
                             <font-awesome-icon icon="plus" class="mr-1"/>
                             {{ tm('term.addParticipant') }}
                         </simple-button>
                     </div>
                     <div v-if="data.participations?.length" class="space-y-3">
-                        <div 
-                            v-for="participation in data.participations" 
+                        <div
+                            v-for="participation in data.participations"
                             :key="participation.id"
                             class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded"
                         >
@@ -225,13 +264,39 @@ const formatDuration = (minutes) => {
                                 </div>
                                 <div>
                                     <p class="font-medium">{{ participation.user?.name }}</p>
-                                    <div class="flex space-x-2 text-xs">
-                                        <Badge :color="participation.is_attend ? 'green' : 'gray'" size="sm">
+                                    <div class="flex flex-wrap items-center gap-2 text-xs mt-1">
+                                        <Badge
+                                            class="cursor-pointer"
+                                            :color="participation.is_attend ? 'green' : 'gray'"
+                                            size="sm"
+                                            @click="updateParticipant(participation, {is_attend: !participation.is_attend})"
+                                        >
                                             {{ participation.is_attend ? tm('term.isAttend') : 'Katılmadı' }}
                                         </Badge>
-                                        <Badge v-if="participation.score !== null" color="blue" size="sm">
-                                            {{ participation.score }} puan
+                                        <Badge
+                                            class="cursor-pointer"
+                                            :color="participation.status ? 'blue' : 'gray'"
+                                            size="sm"
+                                            @click="updateParticipant(participation, {status: !participation.status})"
+                                        >
+                                            {{ participation.status ? 'Başarılı' : 'Başarısız' }}
                                         </Badge>
+                                        <input
+                                            type="number"
+                                            min="0"
+                                            max="100"
+                                            :value="participation.score"
+                                            @change="updateParticipant(participation, {score: $event.target.value === '' ? null : Number($event.target.value)})"
+                                            class="w-16 text-xs rounded border-gray-300 dark:border-gray-600 dark:bg-gray-800"
+                                            placeholder="puan"
+                                        />
+                                        <button
+                                            type="button"
+                                            class="text-red-500 hover:text-red-700"
+                                            @click="removeParticipant(participation)"
+                                        >
+                                            <font-awesome-icon icon="trash-can"/>
+                                        </button>
                                     </div>
                                 </div>
                             </div>
@@ -258,7 +323,7 @@ const formatDuration = (minutes) => {
                                 <p class="font-medium truncate">{{ document.name }}</p>
                                 <p class="text-xs text-gray-500">{{ document.mime_type }}</p>
                             </div>
-                            <simple-button size="sm" color="blue" class="ml-2">
+                            <simple-button size="sm" color="blue" class="ml-2" type="external" :link="document.original_url" download>
                                 <font-awesome-icon icon="download"/>
                             </simple-button>
                         </div>
@@ -270,4 +335,20 @@ const formatDuration = (minutes) => {
             </div>
         </div>
     </app-layout>
+
+    <teleport to="body">
+        <Modal
+            v-model="showAddParticipantModal"
+            :header="tm('term.addParticipant')"
+            closeable
+            close-button
+        >
+            <input-group label-for="participant_user_id" :label="tm('term.participants')">
+                <select-input v-model="newParticipantUserId" :options="candidateUsers" option-key="id" option-label="name"/>
+            </input-group>
+            <template #footer>
+                <SimpleButton :label="t('action.create')" color="green" @click="addParticipant"/>
+            </template>
+        </Modal>
+    </teleport>
 </template> 

--- a/resources/js/Pages/Modules/HumanResources/EducationPlan/ShowPage.vue
+++ b/resources/js/Pages/Modules/HumanResources/EducationPlan/ShowPage.vue
@@ -1,10 +1,12 @@
 <script setup>
 import AppLayout from "@/Layouts/AppLayout.vue";
-import {router} from "@inertiajs/vue3";
+import {Link, router} from "@inertiajs/vue3";
 
 // Components
 import SimpleButton from "@/Components/Button/SimpleButton.vue"
 import Alert from "@/Components/Alert/Alert.vue";
+import Badge from "@/Components/Badge/Badge.vue";
+import HelpButton from "@/Components/Help/HelpButton.vue";
 
 // Props
 const props = defineProps({
@@ -33,6 +35,11 @@ const formatDate = (date) => {
 <app-layout :title="data.name">
 
   <template #actionArea>
+    <help-button title="Eğitim Planı — Nasıl Çalışır?" subtitle="Plan ile eğitimler arası ilişki">
+      <p>Bir <strong>Eğitim Planı</strong>, belirli bir tarih aralığını (başlangıç-bitiş) kapsayan bir gruplama kaydıdır. Tekil <strong>Eğitim</strong> kayıtları oluşturulurken bir plana bağlanır; bu sayfada o plana bağlı tüm eğitimler listelenir.</p>
+      <p>Yeni bir eğitim eklemek için "Eğitimler" listesindeki butonla eğitim listesine gidip oradan planı seçerek oluşturursunuz — eğitim ekleme işlemi bu sayfadan değil, Eğitimler modülünden yapılır.</p>
+    </help-button>
+
     <simple-button @click="handleDelete" color="red">
       <font-awesome-icon icon="trash-can" class="mr-2" />
       <span v-text="tm('action.delete')" />
@@ -72,15 +79,33 @@ const formatDate = (date) => {
       </div>
     </div>
 
-    <!--Educations List (Future feature)-->
+    <!--Educations List-->
     <div class="col-span-12">
       <div class="bg-white dark:bg-slate-800 rounded-lg p-6 shadow">
         <h3 class="text-lg font-semibold mb-4">{{ tm('term.educations') }}</h3>
-        <Alert>
+
+        <div v-if="data.educations?.length" class="space-y-2">
+          <Link
+            v-for="education in data.educations"
+            :key="education.id"
+            :href="route('education.show', education.id)"
+            class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded hover:bg-gray-100 dark:hover:bg-gray-600"
+          >
+            <span class="font-medium">{{ education.name }}</span>
+            <div class="flex items-center gap-2 text-xs">
+              <span>{{ formatDate(education.planned_date) }}</span>
+              <Badge :color="education.is_cancelled ? 'red' : (education.is_completed ? 'green' : 'blue')">
+                {{ education.is_cancelled ? 'İptal Edildi' : (education.is_completed ? 'Tamamlandı' : 'Planlandı') }}
+              </Badge>
+            </div>
+          </Link>
+        </div>
+        <Alert v-else>
           {{ tm('message.feedback.noEducationsInPlan') }}
         </Alert>
+
         <!--Add Education-->
-        <simple-button class="mt-4" full-size color="green">
+        <simple-button class="mt-4" full-size color="green" type="route" :link="route('education.index')">
           <font-awesome-icon icon="fa-solid fa-plus"/>
           <span v-text="tm('action.addEducation')"/>
         </simple-button>

--- a/resources/js/actions/App/Http/Controllers/HumanResources/Education/EducationController.ts
+++ b/resources/js/actions/App/Http/Controllers/HumanResources/Education/EducationController.ts
@@ -1,7 +1,7 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education/search'
  */
 const indexa8735a071e6dab784766a8f4a44ba5b6 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -16,7 +16,7 @@ indexa8735a071e6dab784766a8f4a44ba5b6.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education/search'
  */
 indexa8735a071e6dab784766a8f4a44ba5b6.url = (options?: RouteQueryOptions) => {
@@ -25,7 +25,7 @@ indexa8735a071e6dab784766a8f4a44ba5b6.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education/search'
  */
 indexa8735a071e6dab784766a8f4a44ba5b6.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -35,7 +35,7 @@ indexa8735a071e6dab784766a8f4a44ba5b6.post = (options?: RouteQueryOptions): Rout
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education/search'
  */
     const indexa8735a071e6dab784766a8f4a44ba5b6Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -45,7 +45,7 @@ indexa8735a071e6dab784766a8f4a44ba5b6.post = (options?: RouteQueryOptions): Rout
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education/search'
  */
         indexa8735a071e6dab784766a8f4a44ba5b6Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -56,7 +56,7 @@ indexa8735a071e6dab784766a8f4a44ba5b6.post = (options?: RouteQueryOptions): Rout
     indexa8735a071e6dab784766a8f4a44ba5b6.form = indexa8735a071e6dab784766a8f4a44ba5b6Form
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
 const indexab1556230c34a0fb5296bc684bec852b = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -71,7 +71,7 @@ indexab1556230c34a0fb5296bc684bec852b.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
 indexab1556230c34a0fb5296bc684bec852b.url = (options?: RouteQueryOptions) => {
@@ -80,7 +80,7 @@ indexab1556230c34a0fb5296bc684bec852b.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
 indexab1556230c34a0fb5296bc684bec852b.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -89,7 +89,7 @@ indexab1556230c34a0fb5296bc684bec852b.get = (options?: RouteQueryOptions): Route
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
 indexab1556230c34a0fb5296bc684bec852b.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -99,7 +99,7 @@ indexab1556230c34a0fb5296bc684bec852b.head = (options?: RouteQueryOptions): Rout
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
     const indexab1556230c34a0fb5296bc684bec852bForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -109,7 +109,7 @@ indexab1556230c34a0fb5296bc684bec852b.head = (options?: RouteQueryOptions): Rout
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
         indexab1556230c34a0fb5296bc684bec852bForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -118,7 +118,7 @@ indexab1556230c34a0fb5296bc684bec852b.head = (options?: RouteQueryOptions): Rout
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
         indexab1556230c34a0fb5296bc684bec852bForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -145,7 +145,7 @@ export const index = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
 export const create = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -160,7 +160,7 @@ create.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
 create.url = (options?: RouteQueryOptions) => {
@@ -169,7 +169,7 @@ create.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
 create.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -178,7 +178,7 @@ create.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
 create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -188,7 +188,7 @@ create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
     const createForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -198,7 +198,7 @@ create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
         createForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -207,7 +207,7 @@ create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
         createForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -223,7 +223,7 @@ create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     create.form = createForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::store
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:75
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:76
  * @route '/education'
  */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -238,7 +238,7 @@ store.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::store
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:75
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:76
  * @route '/education'
  */
 store.url = (options?: RouteQueryOptions) => {
@@ -247,7 +247,7 @@ store.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::store
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:75
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:76
  * @route '/education'
  */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -257,7 +257,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::store
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:75
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:76
  * @route '/education'
  */
     const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -267,7 +267,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::store
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:75
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:76
  * @route '/education'
  */
         storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -278,7 +278,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     store.form = storeForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
 export const show = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -293,7 +293,7 @@ show.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
 show.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -326,7 +326,7 @@ show.url = (args: { education: number | { id: number } } | [education: number | 
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
 show.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -335,7 +335,7 @@ show.get = (args: { education: number | { id: number } } | [education: number | 
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
 show.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -345,7 +345,7 @@ show.head = (args: { education: number | { id: number } } | [education: number |
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
     const showForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -355,7 +355,7 @@ show.head = (args: { education: number | { id: number } } | [education: number |
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
         showForm.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -364,7 +364,7 @@ show.head = (args: { education: number | { id: number } } | [education: number |
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
         showForm.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -380,7 +380,7 @@ show.head = (args: { education: number | { id: number } } | [education: number |
     show.form = showForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
 export const edit = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -395,7 +395,7 @@ edit.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
 edit.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -428,7 +428,7 @@ edit.url = (args: { education: number | { id: number } } | [education: number | 
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
 edit.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -437,7 +437,7 @@ edit.get = (args: { education: number | { id: number } } | [education: number | 
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
 edit.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -447,7 +447,7 @@ edit.head = (args: { education: number | { id: number } } | [education: number |
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
     const editForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -457,7 +457,7 @@ edit.head = (args: { education: number | { id: number } } | [education: number |
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
         editForm.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -466,7 +466,7 @@ edit.head = (args: { education: number | { id: number } } | [education: number |
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
         editForm.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -482,7 +482,7 @@ edit.head = (args: { education: number | { id: number } } | [education: number |
     edit.form = editForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
 export const update = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -497,7 +497,7 @@ update.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
 update.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -530,7 +530,7 @@ update.url = (args: { education: number | { id: number } } | [education: number 
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
 update.put = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -539,7 +539,7 @@ update.put = (args: { education: number | { id: number } } | [education: number 
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
 update.patch = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -549,7 +549,7 @@ update.patch = (args: { education: number | { id: number } } | [education: numbe
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
     const updateForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -564,7 +564,7 @@ update.patch = (args: { education: number | { id: number } } | [education: numbe
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
         updateForm.put = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -578,7 +578,7 @@ update.patch = (args: { education: number | { id: number } } | [education: numbe
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
         updateForm.patch = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -594,7 +594,7 @@ update.patch = (args: { education: number | { id: number } } | [education: numbe
     update.form = updateForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::destroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:181
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:190
  * @route '/education/{education}'
  */
 export const destroy = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -609,7 +609,7 @@ destroy.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::destroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:181
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:190
  * @route '/education/{education}'
  */
 destroy.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -642,7 +642,7 @@ destroy.url = (args: { education: number | { id: number } } | [education: number
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::destroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:181
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:190
  * @route '/education/{education}'
  */
 destroy.delete = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -652,7 +652,7 @@ destroy.delete = (args: { education: number | { id: number } } | [education: num
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::destroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:181
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:190
  * @route '/education/{education}'
  */
     const destroyForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -667,7 +667,7 @@ destroy.delete = (args: { education: number | { id: number } } | [education: num
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::destroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:181
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:190
  * @route '/education/{education}'
  */
         destroyForm.delete = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -683,7 +683,7 @@ destroy.delete = (args: { education: number | { id: number } } | [education: num
     destroy.form = destroyForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
 export const deleted = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -698,7 +698,7 @@ deleted.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
 deleted.url = (options?: RouteQueryOptions) => {
@@ -707,7 +707,7 @@ deleted.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
 deleted.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -716,7 +716,7 @@ deleted.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
 deleted.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -726,7 +726,7 @@ deleted.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
     const deletedForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -736,7 +736,7 @@ deleted.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
         deletedForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -745,7 +745,7 @@ deleted.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
         deletedForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -761,7 +761,7 @@ deleted.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     deleted.form = deletedForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::permanentDestroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:195
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:204
  * @route '/education-permanent-delete/{education}'
  */
 export const permanentDestroy = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -776,7 +776,7 @@ permanentDestroy.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::permanentDestroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:195
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:204
  * @route '/education-permanent-delete/{education}'
  */
 permanentDestroy.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -809,7 +809,7 @@ permanentDestroy.url = (args: { education: number | { id: number } } | [educatio
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::permanentDestroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:195
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:204
  * @route '/education-permanent-delete/{education}'
  */
 permanentDestroy.delete = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -819,7 +819,7 @@ permanentDestroy.delete = (args: { education: number | { id: number } } | [educa
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::permanentDestroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:195
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:204
  * @route '/education-permanent-delete/{education}'
  */
     const permanentDestroyForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -834,7 +834,7 @@ permanentDestroy.delete = (args: { education: number | { id: number } } | [educa
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::permanentDestroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:195
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:204
  * @route '/education-permanent-delete/{education}'
  */
         permanentDestroyForm.delete = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -850,7 +850,7 @@ permanentDestroy.delete = (args: { education: number | { id: number } } | [educa
     permanentDestroy.form = permanentDestroyForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
 export const restore = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -865,7 +865,7 @@ restore.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
 restore.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -898,7 +898,7 @@ restore.url = (args: { education: number | { id: number } } | [education: number
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
 restore.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -907,7 +907,7 @@ restore.get = (args: { education: number | { id: number } } | [education: number
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
 restore.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -917,7 +917,7 @@ restore.head = (args: { education: number | { id: number } } | [education: numbe
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
     const restoreForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -927,7 +927,7 @@ restore.head = (args: { education: number | { id: number } } | [education: numbe
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
         restoreForm.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -936,7 +936,7 @@ restore.head = (args: { education: number | { id: number } } | [education: numbe
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
         restoreForm.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -952,7 +952,7 @@ restore.head = (args: { education: number | { id: number } } | [education: numbe
     restore.form = restoreForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::addParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:226
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:235
  * @route '/education/{education}/participants'
  */
 export const addParticipant = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -967,7 +967,7 @@ addParticipant.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::addParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:226
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:235
  * @route '/education/{education}/participants'
  */
 addParticipant.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -1000,7 +1000,7 @@ addParticipant.url = (args: { education: number | { id: number } } | [education:
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::addParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:226
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:235
  * @route '/education/{education}/participants'
  */
 addParticipant.post = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -1010,7 +1010,7 @@ addParticipant.post = (args: { education: number | { id: number } } | [education
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::addParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:226
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:235
  * @route '/education/{education}/participants'
  */
     const addParticipantForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1020,7 +1020,7 @@ addParticipant.post = (args: { education: number | { id: number } } | [education
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::addParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:226
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:235
  * @route '/education/{education}/participants'
  */
         addParticipantForm.post = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1031,7 +1031,7 @@ addParticipant.post = (args: { education: number | { id: number } } | [education
     addParticipant.form = addParticipantForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::updateParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:250
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:259
  * @route '/education/{education}/participants/{user}'
  */
 export const updateParticipant = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -1046,7 +1046,7 @@ updateParticipant.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::updateParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:250
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:259
  * @route '/education/{education}/participants/{user}'
  */
 updateParticipant.url = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions) => {
@@ -1076,7 +1076,7 @@ updateParticipant.url = (args: { education: number | { id: number }, user: numbe
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::updateParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:250
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:259
  * @route '/education/{education}/participants/{user}'
  */
 updateParticipant.put = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -1086,7 +1086,7 @@ updateParticipant.put = (args: { education: number | { id: number }, user: numbe
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::updateParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:250
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:259
  * @route '/education/{education}/participants/{user}'
  */
     const updateParticipantForm = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1101,7 +1101,7 @@ updateParticipant.put = (args: { education: number | { id: number }, user: numbe
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::updateParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:250
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:259
  * @route '/education/{education}/participants/{user}'
  */
         updateParticipantForm.put = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1117,7 +1117,7 @@ updateParticipant.put = (args: { education: number | { id: number }, user: numbe
     updateParticipant.form = updateParticipantForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::removeParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:276
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:285
  * @route '/education/{education}/participants/{user}'
  */
 export const removeParticipant = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -1132,7 +1132,7 @@ removeParticipant.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::removeParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:276
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:285
  * @route '/education/{education}/participants/{user}'
  */
 removeParticipant.url = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions) => {
@@ -1162,7 +1162,7 @@ removeParticipant.url = (args: { education: number | { id: number }, user: numbe
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::removeParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:276
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:285
  * @route '/education/{education}/participants/{user}'
  */
 removeParticipant.delete = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -1172,7 +1172,7 @@ removeParticipant.delete = (args: { education: number | { id: number }, user: nu
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::removeParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:276
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:285
  * @route '/education/{education}/participants/{user}'
  */
     const removeParticipantForm = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1187,7 +1187,7 @@ removeParticipant.delete = (args: { education: number | { id: number }, user: nu
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::removeParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:276
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:285
  * @route '/education/{education}/participants/{user}'
  */
         removeParticipantForm.delete = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1203,7 +1203,7 @@ removeParticipant.delete = (args: { education: number | { id: number }, user: nu
     removeParticipant.form = removeParticipantForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleteMedia
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:292
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:301
  * @route '/education/{education}/media/{mediaId}'
  */
 export const deleteMedia = (args: { education: number | { id: number }, mediaId: string | number } | [education: number | { id: number }, mediaId: string | number ], options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -1218,7 +1218,7 @@ deleteMedia.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleteMedia
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:292
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:301
  * @route '/education/{education}/media/{mediaId}'
  */
 deleteMedia.url = (args: { education: number | { id: number }, mediaId: string | number } | [education: number | { id: number }, mediaId: string | number ], options?: RouteQueryOptions) => {
@@ -1246,7 +1246,7 @@ deleteMedia.url = (args: { education: number | { id: number }, mediaId: string |
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleteMedia
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:292
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:301
  * @route '/education/{education}/media/{mediaId}'
  */
 deleteMedia.delete = (args: { education: number | { id: number }, mediaId: string | number } | [education: number | { id: number }, mediaId: string | number ], options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -1256,7 +1256,7 @@ deleteMedia.delete = (args: { education: number | { id: number }, mediaId: strin
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleteMedia
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:292
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:301
  * @route '/education/{education}/media/{mediaId}'
  */
     const deleteMediaForm = (args: { education: number | { id: number }, mediaId: string | number } | [education: number | { id: number }, mediaId: string | number ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1271,7 +1271,7 @@ deleteMedia.delete = (args: { education: number | { id: number }, mediaId: strin
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleteMedia
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:292
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:301
  * @route '/education/{education}/media/{mediaId}'
  */
         deleteMediaForm.delete = (args: { education: number | { id: number }, mediaId: string | number } | [education: number | { id: number }, mediaId: string | number ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({

--- a/resources/js/routes/education/index.ts
+++ b/resources/js/routes/education/index.ts
@@ -1,7 +1,7 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../wayfinder'
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::search
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education/search'
  */
 export const search = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -16,7 +16,7 @@ search.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::search
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education/search'
  */
 search.url = (options?: RouteQueryOptions) => {
@@ -25,7 +25,7 @@ search.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::search
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education/search'
  */
 search.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -35,7 +35,7 @@ search.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::search
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education/search'
  */
     const searchForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -45,7 +45,7 @@ search.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::search
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education/search'
  */
         searchForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -56,7 +56,7 @@ search.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     search.form = searchForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -71,7 +71,7 @@ index.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
 index.url = (options?: RouteQueryOptions) => {
@@ -80,7 +80,7 @@ index.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -89,7 +89,7 @@ index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -99,7 +99,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
     const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -109,7 +109,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
         indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -118,7 +118,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::index
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:26
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:27
  * @route '/education'
  */
         indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -134,7 +134,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     index.form = indexForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
 export const create = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -149,7 +149,7 @@ create.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
 create.url = (options?: RouteQueryOptions) => {
@@ -158,7 +158,7 @@ create.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
 create.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -167,7 +167,7 @@ create.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
 create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -177,7 +177,7 @@ create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
     const createForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -187,7 +187,7 @@ create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
         createForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -196,7 +196,7 @@ create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::create
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:65
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:66
  * @route '/education/create'
  */
         createForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -212,7 +212,7 @@ create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     create.form = createForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::store
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:75
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:76
  * @route '/education'
  */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -227,7 +227,7 @@ store.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::store
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:75
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:76
  * @route '/education'
  */
 store.url = (options?: RouteQueryOptions) => {
@@ -236,7 +236,7 @@ store.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::store
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:75
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:76
  * @route '/education'
  */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -246,7 +246,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::store
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:75
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:76
  * @route '/education'
  */
     const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -256,7 +256,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::store
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:75
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:76
  * @route '/education'
  */
         storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -267,7 +267,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     store.form = storeForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
 export const show = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -282,7 +282,7 @@ show.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
 show.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -315,7 +315,7 @@ show.url = (args: { education: number | { id: number } } | [education: number | 
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
 show.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -324,7 +324,7 @@ show.get = (args: { education: number | { id: number } } | [education: number | 
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
 show.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -334,7 +334,7 @@ show.head = (args: { education: number | { id: number } } | [education: number |
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
     const showForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -344,7 +344,7 @@ show.head = (args: { education: number | { id: number } } | [education: number |
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
         showForm.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -353,7 +353,7 @@ show.head = (args: { education: number | { id: number } } | [education: number |
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::show
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:112
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:113
  * @route '/education/{education}'
  */
         showForm.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -369,7 +369,7 @@ show.head = (args: { education: number | { id: number } } | [education: number |
     show.form = showForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
 export const edit = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -384,7 +384,7 @@ edit.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
 edit.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -417,7 +417,7 @@ edit.url = (args: { education: number | { id: number } } | [education: number | 
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
 edit.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -426,7 +426,7 @@ edit.get = (args: { education: number | { id: number } } | [education: number | 
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
 edit.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -436,7 +436,7 @@ edit.head = (args: { education: number | { id: number } } | [education: number |
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
     const editForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -446,7 +446,7 @@ edit.head = (args: { education: number | { id: number } } | [education: number |
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
         editForm.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -455,7 +455,7 @@ edit.head = (args: { education: number | { id: number } } | [education: number |
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::edit
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:130
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:139
  * @route '/education/{education}/edit'
  */
         editForm.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -471,7 +471,7 @@ edit.head = (args: { education: number | { id: number } } | [education: number |
     edit.form = editForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
 export const update = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -486,7 +486,7 @@ update.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
 update.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -519,7 +519,7 @@ update.url = (args: { education: number | { id: number } } | [education: number 
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
 update.put = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -528,7 +528,7 @@ update.put = (args: { education: number | { id: number } } | [education: number 
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
 update.patch = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -538,7 +538,7 @@ update.patch = (args: { education: number | { id: number } } | [education: numbe
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
     const updateForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -553,7 +553,7 @@ update.patch = (args: { education: number | { id: number } } | [education: numbe
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
         updateForm.put = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -567,7 +567,7 @@ update.patch = (args: { education: number | { id: number } } | [education: numbe
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::update
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:145
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:154
  * @route '/education/{education}'
  */
         updateForm.patch = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -583,7 +583,7 @@ update.patch = (args: { education: number | { id: number } } | [education: numbe
     update.form = updateForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::destroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:181
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:190
  * @route '/education/{education}'
  */
 export const destroy = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -598,7 +598,7 @@ destroy.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::destroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:181
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:190
  * @route '/education/{education}'
  */
 destroy.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -631,7 +631,7 @@ destroy.url = (args: { education: number | { id: number } } | [education: number
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::destroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:181
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:190
  * @route '/education/{education}'
  */
 destroy.delete = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -641,7 +641,7 @@ destroy.delete = (args: { education: number | { id: number } } | [education: num
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::destroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:181
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:190
  * @route '/education/{education}'
  */
     const destroyForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -656,7 +656,7 @@ destroy.delete = (args: { education: number | { id: number } } | [education: num
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::destroy
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:181
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:190
  * @route '/education/{education}'
  */
         destroyForm.delete = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -672,7 +672,7 @@ destroy.delete = (args: { education: number | { id: number } } | [education: num
     destroy.form = destroyForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
 export const deleted = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -687,7 +687,7 @@ deleted.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
 deleted.url = (options?: RouteQueryOptions) => {
@@ -696,7 +696,7 @@ deleted.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
 deleted.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -705,7 +705,7 @@ deleted.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
 deleted.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -715,7 +715,7 @@ deleted.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
     const deletedForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -725,7 +725,7 @@ deleted.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
         deletedForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -734,7 +734,7 @@ deleted.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleted
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:49
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:50
  * @route '/education-deleted'
  */
         deletedForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -750,7 +750,7 @@ deleted.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     deleted.form = deletedForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::permanentDelete
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:195
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:204
  * @route '/education-permanent-delete/{education}'
  */
 export const permanentDelete = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -765,7 +765,7 @@ permanentDelete.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::permanentDelete
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:195
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:204
  * @route '/education-permanent-delete/{education}'
  */
 permanentDelete.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -798,7 +798,7 @@ permanentDelete.url = (args: { education: number | { id: number } } | [education
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::permanentDelete
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:195
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:204
  * @route '/education-permanent-delete/{education}'
  */
 permanentDelete.delete = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -808,7 +808,7 @@ permanentDelete.delete = (args: { education: number | { id: number } } | [educat
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::permanentDelete
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:195
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:204
  * @route '/education-permanent-delete/{education}'
  */
     const permanentDeleteForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -823,7 +823,7 @@ permanentDelete.delete = (args: { education: number | { id: number } } | [educat
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::permanentDelete
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:195
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:204
  * @route '/education-permanent-delete/{education}'
  */
         permanentDeleteForm.delete = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -839,7 +839,7 @@ permanentDelete.delete = (args: { education: number | { id: number } } | [educat
     permanentDelete.form = permanentDeleteForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
 export const restore = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -854,7 +854,7 @@ restore.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
 restore.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -887,7 +887,7 @@ restore.url = (args: { education: number | { id: number } } | [education: number
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
 restore.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -896,7 +896,7 @@ restore.get = (args: { education: number | { id: number } } | [education: number
 })
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
 restore.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -906,7 +906,7 @@ restore.head = (args: { education: number | { id: number } } | [education: numbe
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
     const restoreForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -916,7 +916,7 @@ restore.head = (args: { education: number | { id: number } } | [education: numbe
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
         restoreForm.get = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -925,7 +925,7 @@ restore.head = (args: { education: number | { id: number } } | [education: numbe
         })
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::restore
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:212
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:221
  * @route '/education-restore/{education}'
  */
         restoreForm.head = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -941,7 +941,7 @@ restore.head = (args: { education: number | { id: number } } | [education: numbe
     restore.form = restoreForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::addParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:226
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:235
  * @route '/education/{education}/participants'
  */
 export const addParticipant = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -956,7 +956,7 @@ addParticipant.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::addParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:226
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:235
  * @route '/education/{education}/participants'
  */
 addParticipant.url = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -989,7 +989,7 @@ addParticipant.url = (args: { education: number | { id: number } } | [education:
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::addParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:226
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:235
  * @route '/education/{education}/participants'
  */
 addParticipant.post = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -999,7 +999,7 @@ addParticipant.post = (args: { education: number | { id: number } } | [education
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::addParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:226
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:235
  * @route '/education/{education}/participants'
  */
     const addParticipantForm = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1009,7 +1009,7 @@ addParticipant.post = (args: { education: number | { id: number } } | [education
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::addParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:226
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:235
  * @route '/education/{education}/participants'
  */
         addParticipantForm.post = (args: { education: number | { id: number } } | [education: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1020,7 +1020,7 @@ addParticipant.post = (args: { education: number | { id: number } } | [education
     addParticipant.form = addParticipantForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::updateParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:250
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:259
  * @route '/education/{education}/participants/{user}'
  */
 export const updateParticipant = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -1035,7 +1035,7 @@ updateParticipant.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::updateParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:250
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:259
  * @route '/education/{education}/participants/{user}'
  */
 updateParticipant.url = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions) => {
@@ -1065,7 +1065,7 @@ updateParticipant.url = (args: { education: number | { id: number }, user: numbe
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::updateParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:250
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:259
  * @route '/education/{education}/participants/{user}'
  */
 updateParticipant.put = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -1075,7 +1075,7 @@ updateParticipant.put = (args: { education: number | { id: number }, user: numbe
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::updateParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:250
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:259
  * @route '/education/{education}/participants/{user}'
  */
     const updateParticipantForm = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1090,7 +1090,7 @@ updateParticipant.put = (args: { education: number | { id: number }, user: numbe
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::updateParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:250
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:259
  * @route '/education/{education}/participants/{user}'
  */
         updateParticipantForm.put = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1106,7 +1106,7 @@ updateParticipant.put = (args: { education: number | { id: number }, user: numbe
     updateParticipant.form = updateParticipantForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::removeParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:276
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:285
  * @route '/education/{education}/participants/{user}'
  */
 export const removeParticipant = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -1121,7 +1121,7 @@ removeParticipant.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::removeParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:276
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:285
  * @route '/education/{education}/participants/{user}'
  */
 removeParticipant.url = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions) => {
@@ -1151,7 +1151,7 @@ removeParticipant.url = (args: { education: number | { id: number }, user: numbe
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::removeParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:276
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:285
  * @route '/education/{education}/participants/{user}'
  */
 removeParticipant.delete = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -1161,7 +1161,7 @@ removeParticipant.delete = (args: { education: number | { id: number }, user: nu
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::removeParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:276
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:285
  * @route '/education/{education}/participants/{user}'
  */
     const removeParticipantForm = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1176,7 +1176,7 @@ removeParticipant.delete = (args: { education: number | { id: number }, user: nu
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::removeParticipant
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:276
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:285
  * @route '/education/{education}/participants/{user}'
  */
         removeParticipantForm.delete = (args: { education: number | { id: number }, user: number | { id: number } } | [education: number | { id: number }, user: number | { id: number } ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1192,7 +1192,7 @@ removeParticipant.delete = (args: { education: number | { id: number }, user: nu
     removeParticipant.form = removeParticipantForm
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleteMedia
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:292
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:301
  * @route '/education/{education}/media/{mediaId}'
  */
 export const deleteMedia = (args: { education: number | { id: number }, mediaId: string | number } | [education: number | { id: number }, mediaId: string | number ], options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -1207,7 +1207,7 @@ deleteMedia.definition = {
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleteMedia
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:292
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:301
  * @route '/education/{education}/media/{mediaId}'
  */
 deleteMedia.url = (args: { education: number | { id: number }, mediaId: string | number } | [education: number | { id: number }, mediaId: string | number ], options?: RouteQueryOptions) => {
@@ -1235,7 +1235,7 @@ deleteMedia.url = (args: { education: number | { id: number }, mediaId: string |
 
 /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleteMedia
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:292
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:301
  * @route '/education/{education}/media/{mediaId}'
  */
 deleteMedia.delete = (args: { education: number | { id: number }, mediaId: string | number } | [education: number | { id: number }, mediaId: string | number ], options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -1245,7 +1245,7 @@ deleteMedia.delete = (args: { education: number | { id: number }, mediaId: strin
 
     /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleteMedia
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:292
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:301
  * @route '/education/{education}/media/{mediaId}'
  */
     const deleteMediaForm = (args: { education: number | { id: number }, mediaId: string | number } | [education: number | { id: number }, mediaId: string | number ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -1260,7 +1260,7 @@ deleteMedia.delete = (args: { education: number | { id: number }, mediaId: strin
 
             /**
 * @see \App\Http\Controllers\HumanResources\Education\EducationController::deleteMedia
- * @see app/Http/Controllers/HumanResources/Education/EducationController.php:292
+ * @see app/Http/Controllers/HumanResources/Education/EducationController.php:301
  * @route '/education/{education}/media/{mediaId}'
  */
         deleteMediaForm.delete = (args: { education: number | { id: number }, mediaId: string | number } | [education: number | { id: number }, mediaId: string | number ], options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({


### PR DESCRIPTION
## Özet
- Eğitim Detayı (`Education/ShowPage.vue`) ve Eğitim Planı Detayı (`EducationPlan/ShowPage.vue`) sayfalarına gerçek backend davranışına dayanan "Nasıl Çalışır?" yardım panelleri eklendi.
- **Ölü buton bulundu ve giderildi:** "Katılımcıları Yönet" butonunun hiçbir `@click` handler'ı yoktu — tıklanınca hiçbir şey olmuyordu. Kaldırıldı; yerine zaten var olan "Katılımcı Ekle" butonu, backend'de tam hazır olan `education.add-participant` / `update-participant` / `remove-participant` uçlarına bağlandı.
- Katılımcı satırlarına: Katıldı/Başarılı toggle rozetleri, 0-100 puan girişi ve katılımcı çıkarma eklendi.
- Doküman indirme butonu, Document modülündeki mevcut `type="external" download` örüntüsüyle media URL'sine bağlandı.
- Eğitim Planı detayındaki "Eğitimler" listesi kod içinde açıkça `Future feature` olarak işaretlenmiş, her koşulda boş görünen sahte bir alandı (backend `EducationPlan::educations()` ilişkisi zaten vardı, sadece controller'da yüklenmiyor ve Vue'da render edilmiyordu) — artık gerçek veriyle listeleniyor.

## Neden
Kalibrasyon modülünde olduğu gibi, yardım paneli eklerken sayfanın gerçek davranışını doğrularken bu ölü/sahte UI parçaları ortaya çıktı. Arka uç zaten tam hazır olduğundan (route'lar, controller metodları, validasyon) UI'ı bağlamak küçük ve düşük riskliydi; belgelemeden önce "çalışmayan bir özelliği çalışıyormuş gibi anlatmamak" ilkesiyle önce gerçek işlevi kurdum.

Eğitim modülünün "Modül Ayarları" (Eğitmen/Tür/Genel Ayarlar) hub'ı bu PR'dan önce zaten doğru kurulmuştu — bilgi mimarisi tarafında değişiklik yok.

## Test Planı
- [x] `php artisan test` — 334 test, 330 geçti, 4 skip (temel çizgiyle birebir aynı, regresyon yok)
- [x] `npm run build` — başarılı
- [x] Chrome ile uçtan uca doğrulandı: yardım panelleri doğru boyutta açılıyor, katılımcı ekleme/toggle/puan/çıkarma tam döngüsü çalışıyor, eğitim planı sayfasında bağlı eğitim listeleniyor ve doğru sayfaya yönlendiriyor, konsolda hata yok

🤖 Generated with [Claude Code](https://claude.com/claude-code)