### PR TITLE
fix: kalibrasyon görevi düzenleme/tamamlama akışını ekle

### DIFF
--- a/app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php
+++ b/app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php
@@ -50,9 +50,9 @@ class MeasurementDeviceCalibrationTaskController extends Controller
      *
      * @return Response
      */
-    public function show(MeasurementDeviceCalibrationTask $measurementDeviceCalibrationTask)
+    public function show(MeasurementDeviceCalibrationTask $measurementDeviceCalibration)
     {
-        return response()->json($measurementDeviceCalibrationTask->load(['device', 'firm']));
+        return response()->json($measurementDeviceCalibration->load(['device', 'firm']));
     }
 
     /**
@@ -60,9 +60,9 @@ class MeasurementDeviceCalibrationTaskController extends Controller
      *
      * @return Response
      */
-    public function edit(MeasurementDeviceCalibrationTask $measurementDeviceCalibrationTask)
+    public function edit(MeasurementDeviceCalibrationTask $measurementDeviceCalibration)
     {
-        return response()->json($measurementDeviceCalibrationTask);
+        return response()->json($measurementDeviceCalibration);
     }
 
     /**
@@ -70,9 +70,11 @@ class MeasurementDeviceCalibrationTaskController extends Controller
      *
      * @return Response
      */
-    public function update(UpdateMeasurementDeviceCalibrationTaskRequest $request, MeasurementDeviceCalibrationTask $measurementDeviceCalibrationTask)
+    public function update(UpdateMeasurementDeviceCalibrationTaskRequest $request, MeasurementDeviceCalibrationTask $measurementDeviceCalibration)
     {
-        $measurementDeviceCalibrationTask->update($request->validated());
+        $measurementDeviceCalibration->update($request->validated());
+
+        session()->flash('message', ['type' => 'success', 'content' => __('messages.measurementDeviceCalibration.updated', ['measurementDeviceCalibration' => $measurementDeviceCalibration->id])]);
 
         return redirect()->back();
     }

--- a/resources/js/Pages/Modules/MeasurementDevice/Device/Pages/Calibration.vue
+++ b/resources/js/Pages/Modules/MeasurementDevice/Device/Pages/Calibration.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {ref} from "vue";
+import {ref, watch} from "vue";
 import {useForm, router} from "@inertiajs/vue3";
 import ShowPage from "@/Pages/Modules/MeasurementDevice/Device/ShowPage.vue";
 import EmptySource from "@/Components/Content/EmptySource.vue"
@@ -11,6 +11,7 @@ import FormSection from "@/Components/Form/FormSection.vue"
 import InputGroup from "@/Components/Form/InputGroup.vue"
 import TextInput from "@/Components/Form/TextInput.vue"
 import SelectInput from "@/Components/Form/SelectInput.vue"
+import SwitchInput from "@/Components/Form/SwitchInput.vue"
 import relativeTime from "dayjs/plugin/relativeTime";
 
 // Multi-lang
@@ -51,9 +52,11 @@ const headers = [
 ]
 
 const showTaskCreateModal = ref(false);
+const formType = ref('create');
 
 const period = ref('');
 const form = useForm({
+  id: null,
   planned_date: '',
   accomplished_date: '',
   measurement_device_id: props.measurementDevice.id,
@@ -69,17 +72,51 @@ const rules = ref({
 })
 const v$ = useVuelidate(rules, form)
 
+watch(() => form.status, (status) => {
+  if (!status) form.accomplished_date = '';
+})
+
+const openCreate = () => {
+  form.reset();
+  v$.value.$reset();
+  formType.value = 'create';
+  showTaskCreateModal.value = true;
+}
+
 const handleSubmit = async () => {
   const isValidated = await v$.value.$validate()
   if (!isValidated) return
 
-  form.post(route('measurement-device-calibration.store'), {
-    onSuccess: () => {
-      form.reset();
-      showTaskCreateModal.value = false;
-      v$.value.$reset();
-    }
-  })
+  if (formType.value === 'create') {
+    form.post(route('measurement-device-calibration.store'), {
+      onSuccess: () => {
+        form.reset();
+        showTaskCreateModal.value = false;
+        v$.value.$reset();
+      }
+    })
+  } else {
+    form.put(route('measurement-device-calibration.update', {id: form.id}), {
+      onSuccess: () => {
+        form.reset();
+        showTaskCreateModal.value = false;
+        v$.value.$reset();
+      }
+    })
+  }
+}
+
+const getRowInfo = (row) => {
+  form.id = row.id;
+  form.planned_date = dayjs(row.planned_date).format('YYYY-MM-DD');
+  form.accomplished_date = row.accomplished_date ? dayjs(row.accomplished_date).format('YYYY-MM-DD') : '';
+  form.measurement_device_id = row.measurement_device_id;
+  form.calibration_firm_id = row.calibration_firm_id;
+  form.price = row.price;
+  form.currency = row.currency;
+  form.status = row.status;
+  formType.value = 'update';
+  showTaskCreateModal.value = true;
 }
 
 const handleDelete = (id) => {
@@ -95,10 +132,12 @@ dayjs.extend(relativeTime)
           :data="calibrationTasks"
           :headers="headers"
           @delete="handleDelete($event.id)"
+          @edit="getRowInfo"
+          edit-action
           delete-action
       >
         <template #actionArea>
-          <SimpleButton @click="showTaskCreateModal = true" :label="tm('action.createCalibrationTask')"/>
+          <SimpleButton @click="openCreate" :label="tm('action.createCalibrationTask')"/>
         </template>
 
         <template #planned_date="{props}">
@@ -131,14 +170,14 @@ dayjs.extend(relativeTime)
         :message="tm('message.feedback.emptyCalibrationTasksList')"
         :add-new-text="tm('action.createCalibrationTask')"
         class="mt-6"
-        :add-new-callback="()=>{showTaskCreateModal = true}"
+        :add-new-callback="openCreate"
     ></EmptySource>
 
-    <!--Calibration Task Create Form-->
+    <!--Calibration Task Create/Update Form-->
     <Modal
         v-model="showTaskCreateModal"
-        :header="tm('title.createCalibrationModal.title')"
-        :sub-header="tm('title.createCalibrationModal.subTitle')"
+        :header="formType === 'create' ? tm('title.createCalibrationModal.title') : tm('title.updateCalibrationModal.title')"
+        :sub-header="formType === 'create' ? tm('title.createCalibrationModal.subTitle') : tm('title.updateCalibrationModal.subTitle')"
         closeable
         close-button
     >
@@ -171,11 +210,26 @@ dayjs.extend(relativeTime)
           <InputGroup class="col-span-6" label-for="currency" :label="t('term.currency')">
             <TextInput v-model="form.currency"/>
           </InputGroup>
+
+          <!--Accomplished?-->
+          <InputGroup class="col-span-6" label-for="status" :label="tm('term.isAccomplished')">
+            <SwitchInput v-model="form.status"/>
+          </InputGroup>
+
+          <!--Accomplished Date-->
+          <InputGroup v-if="form.status" class="col-span-6" label-for="accomplished_date" :label="t('term.accomplishedDate')">
+            <TextInput v-model="form.accomplished_date" input-type="date"/>
+          </InputGroup>
         </FormSection>
       </Form>
       <template #footer>
         <SimpleButton :label="t('action.cancel')" color="neutral" @click="showTaskCreateModal=false"/>
-        <SimpleButton :label="tm('action.createTask')" color="green" @click="handleSubmit" :loading="form.processing"/>
+        <SimpleButton
+            :label="formType === 'create' ? tm('action.createTask') : tm('action.updateTask')"
+            color="green"
+            @click="handleSubmit"
+            :loading="form.processing"
+        />
       </template>
     </Modal>
   </ShowPage>

--- a/resources/js/Pages/Modules/MeasurementDevice/Device/ShowPage.vue
+++ b/resources/js/Pages/Modules/MeasurementDevice/Device/ShowPage.vue
@@ -53,7 +53,7 @@ const handleDelete = () => {
     <template #actionArea>
       <help-button title="Cihaz Detayı — Nasıl Çalışır?" subtitle="Cihaz bilgisi ve kalibrasyon takibi buradan yönetilir">
         <p><strong>Cihaz Bilgisi:</strong> Cihazın tipi, markası/modeli, seri numarası, satın alma bilgileri ve cihazdan/kalibrasyonundan sorumlu kişiler burada tutulur.</p>
-        <p><strong>Kalibrasyon Görevleri:</strong> Bu cihaz için planlanan her kalibrasyon (planlanan tarih, kalibrasyon firması, ücret) ayrı bir görev olarak kaydedilir. Durum rozeti görevin tamamlanıp tamamlanmadığını gösterir.</p>
+        <p><strong>Kalibrasyon Görevleri:</strong> Bu cihaz için planlanan her kalibrasyon (planlanan tarih, kalibrasyon firması, ücret) ayrı bir görev olarak kaydedilir. Bir görevi düzenle ikonuyla açıp "Gerçekleşti mi?" ile tamamlandı olarak işaretleyebilir ve gerçekleşme tarihini girebilirsiniz — durum rozeti buna göre güncellenir.</p>
       </help-button>
       <simple-button @click="handleDelete" color="red">
         <font-awesome-icon icon="trash-can" class="mr-2"/>

--- a/resources/js/Pages/Modules/MeasurementDevice/Device/translates/en.json
+++ b/resources/js/Pages/Modules/MeasurementDevice/Device/translates/en.json
@@ -11,6 +11,10 @@
     "createCalibrationModal": {
       "title": "Create a Calibration Task",
       "subTitle": "Create a calibration task for your device"
+    },
+    "updateCalibrationModal": {
+      "title": "Update Calibration Task",
+      "subTitle": "Update the calibration task's status and details"
     }
   },
   "term": {
@@ -37,7 +41,8 @@
     "calibrationFirm": "Calibration Firm",
     "calibrationFee": "Calibration Fee",
     "active": "Active",
-    "accomplished": "Accomplished"
+    "accomplished": "Accomplished",
+    "isAccomplished": "Accomplished?"
   },
   "message": {
     "feedback": {
@@ -46,6 +51,7 @@
   },
   "action": {
     "createCalibrationTask": "Create a Calibration Task",
-    "createTask": "Create Task"
+    "createTask": "Create Task",
+    "updateTask": "Update Task"
   }
 }

--- a/resources/js/Pages/Modules/MeasurementDevice/Device/translates/tr.json
+++ b/resources/js/Pages/Modules/MeasurementDevice/Device/translates/tr.json
@@ -11,6 +11,10 @@
     "createCalibrationModal": {
       "title": "Kalibrasyon Emri Oluştur",
       "subTitle": "Cihaz için kalibrasyon emri oluşturun"
+    },
+    "updateCalibrationModal": {
+      "title": "Kalibrasyon Emrini Güncelle",
+      "subTitle": "Kalibrasyon emrinin durumunu ve bilgilerini güncelleyin"
     }
   },
   "term": {
@@ -37,7 +41,8 @@
     "calibrationFirm": "Kalibrasyon Firması",
     "calibrationFee": "Kalibrasyon Ücreti",
     "active": "Aktif",
-    "accomplished": "Gerçekleşti"
+    "accomplished": "Gerçekleşti",
+    "isAccomplished": "Gerçekleşti mi?"
   },
   "message":{
     "feedback" : {
@@ -46,6 +51,7 @@
   },
   "action": {
     "createCalibrationTask": "Kalibrasyon Emri Oluştur",
-    "createTask": "Emri Oluştur"
+    "createTask": "Emri Oluştur",
+    "updateTask": "Emri Güncelle"
   }
 }

--- a/resources/js/actions/App/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.ts
+++ b/resources/js/actions/App/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.ts
@@ -281,7 +281,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-export const show = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+export const show = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
@@ -296,11 +296,14 @@ show.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-show.url = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions) => {
+show.url = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_calibration: args }
     }
 
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { measurement_device_calibration: args.id }
+        }
     
     if (Array.isArray(args)) {
         args = {
@@ -311,7 +314,9 @@ show.url = (args: { measurement_device_calibration: string | number } | [measure
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-                        measurement_device_calibration: args.measurement_device_calibration,
+                        measurement_device_calibration: typeof args.measurement_device_calibration === 'object'
+                ? args.measurement_device_calibration.id
+                : args.measurement_device_calibration,
                 }
 
     return show.definition.url
@@ -324,7 +329,7 @@ show.url = (args: { measurement_device_calibration: string | number } | [measure
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-show.get = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+show.get = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
@@ -333,7 +338,7 @@ show.get = (args: { measurement_device_calibration: string | number } | [measure
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-show.head = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+show.head = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
@@ -343,7 +348,7 @@ show.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-    const showForm = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+    const showForm = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
         action: show.url(args, options),
         method: 'get',
     })
@@ -353,7 +358,7 @@ show.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-        showForm.get = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        showForm.get = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: show.url(args, options),
             method: 'get',
         })
@@ -362,7 +367,7 @@ show.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-        showForm.head = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        showForm.head = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: show.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'HEAD',
@@ -378,7 +383,7 @@ show.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-export const edit = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+export const edit = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(args, options),
     method: 'get',
 })
@@ -393,11 +398,14 @@ edit.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-edit.url = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions) => {
+edit.url = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_calibration: args }
     }
 
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { measurement_device_calibration: args.id }
+        }
     
     if (Array.isArray(args)) {
         args = {
@@ -408,7 +416,9 @@ edit.url = (args: { measurement_device_calibration: string | number } | [measure
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-                        measurement_device_calibration: args.measurement_device_calibration,
+                        measurement_device_calibration: typeof args.measurement_device_calibration === 'object'
+                ? args.measurement_device_calibration.id
+                : args.measurement_device_calibration,
                 }
 
     return edit.definition.url
@@ -421,7 +431,7 @@ edit.url = (args: { measurement_device_calibration: string | number } | [measure
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-edit.get = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+edit.get = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(args, options),
     method: 'get',
 })
@@ -430,7 +440,7 @@ edit.get = (args: { measurement_device_calibration: string | number } | [measure
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-edit.head = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+edit.head = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: edit.url(args, options),
     method: 'head',
 })
@@ -440,7 +450,7 @@ edit.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-    const editForm = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+    const editForm = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
         action: edit.url(args, options),
         method: 'get',
     })
@@ -450,7 +460,7 @@ edit.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-        editForm.get = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        editForm.get = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: edit.url(args, options),
             method: 'get',
         })
@@ -459,7 +469,7 @@ edit.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-        editForm.head = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        editForm.head = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: edit.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'HEAD',
@@ -475,7 +485,7 @@ edit.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-export const update = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+export const update = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(args, options),
     method: 'put',
 })
@@ -490,11 +500,14 @@ update.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-update.url = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions) => {
+update.url = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_calibration: args }
     }
 
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { measurement_device_calibration: args.id }
+        }
     
     if (Array.isArray(args)) {
         args = {
@@ -505,7 +518,9 @@ update.url = (args: { measurement_device_calibration: string | number } | [measu
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-                        measurement_device_calibration: args.measurement_device_calibration,
+                        measurement_device_calibration: typeof args.measurement_device_calibration === 'object'
+                ? args.measurement_device_calibration.id
+                : args.measurement_device_calibration,
                 }
 
     return update.definition.url
@@ -518,7 +533,7 @@ update.url = (args: { measurement_device_calibration: string | number } | [measu
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-update.put = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+update.put = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(args, options),
     method: 'put',
 })
@@ -527,7 +542,7 @@ update.put = (args: { measurement_device_calibration: string | number } | [measu
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-update.patch = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+update.patch = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
     url: update.url(args, options),
     method: 'patch',
 })
@@ -537,7 +552,7 @@ update.patch = (args: { measurement_device_calibration: string | number } | [mea
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-    const updateForm = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+    const updateForm = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
         action: update.url(args, {
                     [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                         _method: 'PUT',
@@ -552,7 +567,7 @@ update.patch = (args: { measurement_device_calibration: string | number } | [mea
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-        updateForm.put = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        updateForm.put = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
             action: update.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'PUT',
@@ -566,7 +581,7 @@ update.patch = (args: { measurement_device_calibration: string | number } | [mea
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-        updateForm.patch = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        updateForm.patch = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
             action: update.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'PATCH',
@@ -579,7 +594,7 @@ update.patch = (args: { measurement_device_calibration: string | number } | [mea
     update.form = updateForm
 /**
 * @see \App\Http\Controllers\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTaskController::destroy
- * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:85
+ * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:87
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
 export const destroy = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -594,7 +609,7 @@ destroy.definition = {
 
 /**
 * @see \App\Http\Controllers\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTaskController::destroy
- * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:85
+ * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:87
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
 destroy.url = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -627,7 +642,7 @@ destroy.url = (args: { measurement_device_calibration: number | { id: number } }
 
 /**
 * @see \App\Http\Controllers\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTaskController::destroy
- * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:85
+ * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:87
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
 destroy.delete = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -637,7 +652,7 @@ destroy.delete = (args: { measurement_device_calibration: number | { id: number 
 
     /**
 * @see \App\Http\Controllers\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTaskController::destroy
- * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:85
+ * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:87
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
     const destroyForm = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -652,7 +667,7 @@ destroy.delete = (args: { measurement_device_calibration: number | { id: number 
 
             /**
 * @see \App\Http\Controllers\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTaskController::destroy
- * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:85
+ * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:87
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
         destroyForm.delete = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({

--- a/resources/js/routes/measurement-device-calibration/index.ts
+++ b/resources/js/routes/measurement-device-calibration/index.ts
@@ -270,7 +270,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-export const show = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+export const show = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
@@ -285,11 +285,14 @@ show.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-show.url = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions) => {
+show.url = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_calibration: args }
     }
 
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { measurement_device_calibration: args.id }
+        }
     
     if (Array.isArray(args)) {
         args = {
@@ -300,7 +303,9 @@ show.url = (args: { measurement_device_calibration: string | number } | [measure
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-                        measurement_device_calibration: args.measurement_device_calibration,
+                        measurement_device_calibration: typeof args.measurement_device_calibration === 'object'
+                ? args.measurement_device_calibration.id
+                : args.measurement_device_calibration,
                 }
 
     return show.definition.url
@@ -313,7 +318,7 @@ show.url = (args: { measurement_device_calibration: string | number } | [measure
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-show.get = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+show.get = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
@@ -322,7 +327,7 @@ show.get = (args: { measurement_device_calibration: string | number } | [measure
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-show.head = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+show.head = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
@@ -332,7 +337,7 @@ show.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-    const showForm = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+    const showForm = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
         action: show.url(args, options),
         method: 'get',
     })
@@ -342,7 +347,7 @@ show.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-        showForm.get = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        showForm.get = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: show.url(args, options),
             method: 'get',
         })
@@ -351,7 +356,7 @@ show.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:53
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-        showForm.head = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        showForm.head = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: show.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'HEAD',
@@ -367,7 +372,7 @@ show.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-export const edit = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+export const edit = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(args, options),
     method: 'get',
 })
@@ -382,11 +387,14 @@ edit.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-edit.url = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions) => {
+edit.url = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_calibration: args }
     }
 
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { measurement_device_calibration: args.id }
+        }
     
     if (Array.isArray(args)) {
         args = {
@@ -397,7 +405,9 @@ edit.url = (args: { measurement_device_calibration: string | number } | [measure
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-                        measurement_device_calibration: args.measurement_device_calibration,
+                        measurement_device_calibration: typeof args.measurement_device_calibration === 'object'
+                ? args.measurement_device_calibration.id
+                : args.measurement_device_calibration,
                 }
 
     return edit.definition.url
@@ -410,7 +420,7 @@ edit.url = (args: { measurement_device_calibration: string | number } | [measure
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-edit.get = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+edit.get = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(args, options),
     method: 'get',
 })
@@ -419,7 +429,7 @@ edit.get = (args: { measurement_device_calibration: string | number } | [measure
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-edit.head = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+edit.head = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: edit.url(args, options),
     method: 'head',
 })
@@ -429,7 +439,7 @@ edit.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-    const editForm = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+    const editForm = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
         action: edit.url(args, options),
         method: 'get',
     })
@@ -439,7 +449,7 @@ edit.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-        editForm.get = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        editForm.get = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: edit.url(args, options),
             method: 'get',
         })
@@ -448,7 +458,7 @@ edit.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:63
  * @route '/measurement-device-calibration/{measurement_device_calibration}/edit'
  */
-        editForm.head = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        editForm.head = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: edit.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'HEAD',
@@ -464,7 +474,7 @@ edit.head = (args: { measurement_device_calibration: string | number } | [measur
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-export const update = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+export const update = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(args, options),
     method: 'put',
 })
@@ -479,11 +489,14 @@ update.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-update.url = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions) => {
+update.url = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_calibration: args }
     }
 
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { measurement_device_calibration: args.id }
+        }
     
     if (Array.isArray(args)) {
         args = {
@@ -494,7 +507,9 @@ update.url = (args: { measurement_device_calibration: string | number } | [measu
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-                        measurement_device_calibration: args.measurement_device_calibration,
+                        measurement_device_calibration: typeof args.measurement_device_calibration === 'object'
+                ? args.measurement_device_calibration.id
+                : args.measurement_device_calibration,
                 }
 
     return update.definition.url
@@ -507,7 +522,7 @@ update.url = (args: { measurement_device_calibration: string | number } | [measu
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-update.put = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+update.put = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(args, options),
     method: 'put',
 })
@@ -516,7 +531,7 @@ update.put = (args: { measurement_device_calibration: string | number } | [measu
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-update.patch = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+update.patch = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
     url: update.url(args, options),
     method: 'patch',
 })
@@ -526,7 +541,7 @@ update.patch = (args: { measurement_device_calibration: string | number } | [mea
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-    const updateForm = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+    const updateForm = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
         action: update.url(args, {
                     [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                         _method: 'PUT',
@@ -541,7 +556,7 @@ update.patch = (args: { measurement_device_calibration: string | number } | [mea
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-        updateForm.put = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        updateForm.put = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
             action: update.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'PUT',
@@ -555,7 +570,7 @@ update.patch = (args: { measurement_device_calibration: string | number } | [mea
  * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:73
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
-        updateForm.patch = (args: { measurement_device_calibration: string | number } | [measurement_device_calibration: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        updateForm.patch = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
             action: update.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'PATCH',
@@ -568,7 +583,7 @@ update.patch = (args: { measurement_device_calibration: string | number } | [mea
     update.form = updateForm
 /**
 * @see \App\Http\Controllers\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTaskController::destroy
- * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:85
+ * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:87
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
 export const destroy = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -583,7 +598,7 @@ destroy.definition = {
 
 /**
 * @see \App\Http\Controllers\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTaskController::destroy
- * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:85
+ * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:87
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
 destroy.url = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -616,7 +631,7 @@ destroy.url = (args: { measurement_device_calibration: number | { id: number } }
 
 /**
 * @see \App\Http\Controllers\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTaskController::destroy
- * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:85
+ * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:87
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
 destroy.delete = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -626,7 +641,7 @@ destroy.delete = (args: { measurement_device_calibration: number | { id: number 
 
     /**
 * @see \App\Http\Controllers\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTaskController::destroy
- * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:85
+ * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:87
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
     const destroyForm = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
@@ -641,7 +656,7 @@ destroy.delete = (args: { measurement_device_calibration: number | { id: number 
 
             /**
 * @see \App\Http\Controllers\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTaskController::destroy
- * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:85
+ * @see app/Http/Controllers/MeasurementDevice/Calibration/MeasurementDeviceCalibrationTaskController.php:87
  * @route '/measurement-device-calibration/{measurement_device_calibration}'
  */
         destroyForm.delete = (args: { measurement_device_calibration: number | { id: number } } | [measurement_device_calibration: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({

--- a/tests/Feature/MeasurementDeviceCalibrationTaskControllerTest.php
+++ b/tests/Feature/MeasurementDeviceCalibrationTaskControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Models\MeasurementDevice\Calibration\CalibrationFirm;
+use App\Models\MeasurementDevice\Calibration\MeasurementDeviceCalibrationTask;
+use App\Models\MeasurementDevice\MeasurementDevice;
+use App\Models\User;
+
+function makeCalibrationFirm(): CalibrationFirm
+{
+    return CalibrationFirm::create([
+        'name' => 'Test Kalibrasyon A.Ş.',
+        'email' => 'info@test-kalibrasyon.com',
+        'address' => 'Test Adres',
+        'phone' => '05000000000',
+    ]);
+}
+
+test('a user can create a calibration task for a device', function () {
+    $device = MeasurementDevice::create(['code' => 'MD-001']);
+    $firm = makeCalibrationFirm();
+
+    $this->actingAs(User::factory()->create())
+        ->post(route('measurement-device-calibration.store'), [
+            'planned_date' => now()->addMonth()->toDateString(),
+            'measurement_device_id' => $device->id,
+            'calibration_firm_id' => $firm->id,
+        ])
+        ->assertSessionHasNoErrors();
+
+    $task = MeasurementDeviceCalibrationTask::first();
+
+    expect($task->measurement_device_id)->toBe($device->id)
+        ->and($task->calibration_firm_id)->toBe($firm->id)
+        ->and($task->status)->toBeFalse();
+});
+
+test('a user can mark a calibration task as accomplished with a date', function () {
+    $device = MeasurementDevice::create(['code' => 'MD-002']);
+    $firm = makeCalibrationFirm();
+    $task = MeasurementDeviceCalibrationTask::create([
+        'planned_date' => now()->subDay()->toDateString(),
+        'measurement_device_id' => $device->id,
+        'calibration_firm_id' => $firm->id,
+        'status' => false,
+    ]);
+
+    $this->actingAs(User::factory()->create())
+        ->put(route('measurement-device-calibration.update', $task), [
+            'planned_date' => $task->planned_date->toDateString(),
+            'accomplished_date' => now()->toDateString(),
+            'measurement_device_id' => $device->id,
+            'calibration_firm_id' => $firm->id,
+            'status' => true,
+        ])
+        ->assertSessionHasNoErrors();
+
+    $task->refresh();
+
+    expect($task->status)->toBeTrue()
+        ->and($task->accomplished_date->toDateString())->toBe(now()->toDateString());
+});
+
+test('accomplished_date must not be before the planned_date', function () {
+    $device = MeasurementDevice::create(['code' => 'MD-003']);
+    $firm = makeCalibrationFirm();
+    $task = MeasurementDeviceCalibrationTask::create([
+        'planned_date' => now()->toDateString(),
+        'measurement_device_id' => $device->id,
+        'calibration_firm_id' => $firm->id,
+        'status' => false,
+    ]);
+
+    $this->actingAs(User::factory()->create())
+        ->put(route('measurement-device-calibration.update', $task), [
+            'planned_date' => $task->planned_date->toDateString(),
+            'accomplished_date' => now()->subDay()->toDateString(),
+            'measurement_device_id' => $device->id,
+            'calibration_firm_id' => $firm->id,
+            'status' => true,
+        ])
+        ->assertSessionHasErrors('accomplished_date');
+});
+
+test('a calibration task can be deleted', function () {
+    $device = MeasurementDevice::create(['code' => 'MD-004']);
+    $firm = makeCalibrationFirm();
+    $task = MeasurementDeviceCalibrationTask::create([
+        'planned_date' => now()->toDateString(),
+        'measurement_device_id' => $device->id,
+        'calibration_firm_id' => $firm->id,
+        'status' => false,
+    ]);
+
+    $this->actingAs(User::factory()->create())
+        ->delete(route('measurement-device-calibration.destroy', $task))
+        ->assertSessionHasNoErrors();
+
+    expect(MeasurementDeviceCalibrationTask::find($task->id))->toBeNull();
+});


### PR DESCRIPTION
## Özet

**Kritik hata bulundu ve düzeltildi:** `MeasurementDeviceCalibrationTaskController`'ın `show()`/`edit()`/`update()` metodlarında route-model-binding parametre adı (`$measurementDeviceCalibrationTask`) route'un ürettiği parametre adıyla (`measurement_device_calibration`) eşleşmiyordu. Laravel isim uyuşmazlığında hata fırlatmak yerine **sessizce yeni, boş bir model örneği** oluşturuyor. Sonuç: bu üç endpoint şimdiye kadar hiçbir zaman gerçek kaydı getirmiyor/güncellemiyordu — `update()` aslında gönderilen veriyle **yeni bir satır** oluşturuyordu, var olan kayıt hiç değişmiyordu (hiçbir hata/uyarı da vermeden). Sadece `destroy()`'un parametre adı (`$measurementDeviceCalibration`, route'la eşleşen) doğru çalıştığı için bu sorun şimdiye kadar fark edilmemişti — arayüzde zaten sadece oluştur+sil vardı, `update()` hiç kullanılmıyordu.

Bunu, kalibrasyon görevi düzenleme özelliğini eklerken (asıl istek) test yazarken buldum: yeni Pest testleri hep başarısız oluyordu çünkü güncelleme sessizce hiçbir şeyi değiştirmiyordu.

## Özellik
Cihaz > Kalibrasyon Görevleri sekmesinde artık bir görev **düzenlenebiliyor**:
- "Gerçekleşti mi?" switch'i açıldığında **Gerçekleşme Tarihi** alanı belirir
- Kaydedildiğinde durum rozeti otomatik "Gerçekleşti"ye döner
- Backend (`update()` + `UpdateMeasurementDeviceCalibrationTaskRequest`, `after_or_equal:planned_date` doğrulaması dahil) zaten hazırdı — eksik olan tek şey arayüzdü ve az önce bulunan binding hatasıydı.

## Test Planı
- [x] `php artisan test` — 354 test, 350 geçti, 4 skip (4 yeni test eklendi, regresyon yok)
- [x] `npm run build` — başarılı
- [x] Chrome ile uçtan uca doğrulandı: görev oluşturuldu, düzenle ikonuyla açıldı, "Gerçekleşti mi?" açılınca tarih alanı belirdi, kaydedildi, tabloda "20.10.2026" ve yeşil "Gerçekleşti" rozeti doğru göründü, konsolda hata yok. Doğrulama için oluşturduğum test verisi temizlendi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)