### PR TITLE
feat: müşteri şikayetleri veri analiz modülü

### DIFF
--- a/app/Http/Controllers/CustomerComplaintAnalyticsController.php
+++ b/app/Http/Controllers/CustomerComplaintAnalyticsController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreCustomerComplaintReportTemplateRequest;
+use App\Http\Requests\UpdateCustomerComplaintReportTemplateRequest;
+use App\Models\CustomerComplaintReportTemplate;
+use App\Services\CustomerComplaint\CustomerComplaintAnalyticsService;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+
+class CustomerComplaintAnalyticsController extends Controller
+{
+    public function index(CustomerComplaintAnalyticsService $analytics)
+    {
+        $defaultBreakdowns = [
+            [
+                'title' => 'Kaynağa Göre Dağılım',
+                'chart_type' => 'bar',
+                'data' => $analytics->breakdown('source_type'),
+            ],
+            [
+                'title' => 'Önem Derecesine Göre Dağılım',
+                'chart_type' => 'pie',
+                'data' => $analytics->breakdown('severity'),
+            ],
+            [
+                'title' => 'Duruma Göre Dağılım',
+                'chart_type' => 'pie',
+                'data' => $analytics->breakdown('status'),
+            ],
+            [
+                'title' => 'Aylık Şikayet Trendi',
+                'chart_type' => 'line',
+                'data' => $analytics->monthlyTrend(),
+            ],
+        ];
+
+        $templates = CustomerComplaintReportTemplate::with('createdBy:id,name')
+            ->where(fn ($query) => $query->where('created_by_id', auth()->id())->orWhere('is_shared', true))
+            ->latest('id')
+            ->get()
+            ->map(function (CustomerComplaintReportTemplate $template) use ($analytics) {
+                $config = $template->config;
+
+                return [
+                    ...$template->toArray(),
+                    'data' => $analytics->breakdown(
+                        $config['group_by'],
+                        $config['metric'] ?? 'count',
+                        $config['date_from'] ?? null,
+                        $config['date_to'] ?? null
+                    ),
+                    'can_manage' => $template->created_by_id === auth()->id(),
+                ];
+            });
+
+        return Inertia::render('Modules/CustomerComplaint/Analytics/IndexPage', [
+            'summary' => $analytics->summary(),
+            'defaultBreakdowns' => $defaultBreakdowns,
+            'templates' => $templates,
+        ]);
+    }
+
+    public function preview(Request $request, CustomerComplaintAnalyticsService $analytics)
+    {
+        $validated = $request->validate([
+            'group_by' => ['required', Rule::in(CustomerComplaintAnalyticsService::DIMENSIONS)],
+            'metric' => ['required', Rule::in(CustomerComplaintAnalyticsService::METRICS)],
+            'date_from' => 'nullable|date',
+            'date_to' => 'nullable|date|after_or_equal:date_from',
+        ]);
+
+        return response()->json($analytics->breakdown(
+            $validated['group_by'],
+            $validated['metric'],
+            $validated['date_from'] ?? null,
+            $validated['date_to'] ?? null
+        ));
+    }
+
+    public function store(StoreCustomerComplaintReportTemplateRequest $request)
+    {
+        CustomerComplaintReportTemplate::create([
+            ...$request->validated(),
+            'created_by_id' => auth()->id(),
+        ]);
+
+        session()->flash('message', ['type' => 'success', 'content' => __('messages.customerComplaintReportTemplate.created')]);
+
+        return redirect()->back();
+    }
+
+    public function update(UpdateCustomerComplaintReportTemplateRequest $request, CustomerComplaintReportTemplate $customerComplaintReportTemplate)
+    {
+        $customerComplaintReportTemplate->update($request->validated());
+
+        session()->flash('message', ['type' => 'success', 'content' => __('messages.customerComplaintReportTemplate.updated')]);
+
+        return redirect()->back();
+    }
+
+    public function destroy(CustomerComplaintReportTemplate $customerComplaintReportTemplate)
+    {
+        abort_if($customerComplaintReportTemplate->created_by_id !== auth()->id(), 403);
+
+        $customerComplaintReportTemplate->delete();
+
+        session()->flash('message', ['type' => 'danger', 'content' => __('messages.customerComplaintReportTemplate.deleted')]);
+
+        return redirect()->back();
+    }
+}

--- a/app/Http/Requests/StoreCustomerComplaintReportTemplateRequest.php
+++ b/app/Http/Requests/StoreCustomerComplaintReportTemplateRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Services\CustomerComplaint\CustomerComplaintAnalyticsService;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreCustomerComplaintReportTemplateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return auth()->check();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'is_shared' => 'sometimes|boolean',
+            'config' => 'required|array',
+            'config.chart_type' => ['required', Rule::in(['bar', 'pie', 'line', 'table'])],
+            'config.group_by' => ['required', Rule::in(CustomerComplaintAnalyticsService::DIMENSIONS)],
+            'config.metric' => ['required', Rule::in(CustomerComplaintAnalyticsService::METRICS)],
+            'config.date_from' => 'nullable|date',
+            'config.date_to' => 'nullable|date|after_or_equal:config.date_from',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCustomerComplaintReportTemplateRequest.php
+++ b/app/Http/Requests/UpdateCustomerComplaintReportTemplateRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Services\CustomerComplaint\CustomerComplaintAnalyticsService;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateCustomerComplaintReportTemplateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->route('customerComplaintReportTemplate')?->created_by_id === auth()->id();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'is_shared' => 'sometimes|boolean',
+            'config' => 'required|array',
+            'config.chart_type' => ['required', Rule::in(['bar', 'pie', 'line', 'table'])],
+            'config.group_by' => ['required', Rule::in(CustomerComplaintAnalyticsService::DIMENSIONS)],
+            'config.metric' => ['required', Rule::in(CustomerComplaintAnalyticsService::METRICS)],
+            'config.date_from' => 'nullable|date',
+            'config.date_to' => 'nullable|date|after_or_equal:config.date_from',
+        ];
+    }
+}

--- a/app/Models/CustomerComplaintReportTemplate.php
+++ b/app/Models/CustomerComplaintReportTemplate.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CustomerComplaintReportTemplate extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'created_by_id',
+        'is_shared',
+        'config',
+    ];
+
+    protected $casts = [
+        'is_shared' => 'boolean',
+        'config' => 'array',
+    ];
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_id');
+    }
+}

--- a/app/Services/CustomerComplaint/CustomerComplaintAnalyticsService.php
+++ b/app/Services/CustomerComplaint/CustomerComplaintAnalyticsService.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Services\CustomerComplaint;
+
+use App\Enums\ComplaintChannel;
+use App\Enums\CustomerComplaintStatus;
+use App\Models\ComplaintSourceType;
+use App\Models\ComplaintSubject;
+use App\Models\CustomerComplaint;
+use App\Models\Department;
+use App\Models\Distributor;
+use App\Models\Supplier;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class CustomerComplaintAnalyticsService
+{
+    public const DIMENSIONS = ['source_type', 'subject', 'severity', 'status', 'channel', 'department', 'distributor', 'supplier', 'month'];
+
+    public const METRICS = ['count', 'avg_resolution_days'];
+
+    private const SEVERITY_LABELS = [
+        'low' => 'Düşük',
+        'medium' => 'Orta',
+        'high' => 'Yüksek',
+        'critical' => 'Kritik',
+    ];
+
+    public function summary(): array
+    {
+        $total = CustomerComplaint::count();
+
+        $byStatus = CustomerComplaint::selectRaw('status, count(*) as count')
+            ->groupBy('status')
+            ->pluck('count', 'status');
+
+        $avgResolutionDays = CustomerComplaint::whereNotNull('closed_at')
+            ->selectRaw("AVG({$this->resolutionDaysExpression()}) as value")
+            ->value('value');
+
+        $overdueCount = CustomerComplaint::whereNotNull('response_due_date')
+            ->where('response_due_date', '<', now())
+            ->whereNotIn('status', [CustomerComplaintStatus::Resolved->value, CustomerComplaintStatus::Closed->value])
+            ->count();
+
+        return [
+            'total' => $total,
+            'open' => $total - (int) ($byStatus[CustomerComplaintStatus::Closed->value] ?? 0),
+            'avg_resolution_days' => $avgResolutionDays !== null ? round((float) $avgResolutionDays, 1) : null,
+            'overdue' => $overdueCount,
+        ];
+    }
+
+    public function monthlyTrend(int $months = 12): array
+    {
+        $from = now()->subMonths($months - 1)->startOfMonth();
+
+        $rows = CustomerComplaint::where('received_date', '>=', $from)
+            ->selectRaw("{$this->monthBucketExpression('received_date')} as bucket, count(*) as value")
+            ->groupBy('bucket')
+            ->orderBy('bucket')
+            ->pluck('value', 'bucket');
+
+        $labels = [];
+        $values = [];
+        for ($i = 0; $i < $months; $i++) {
+            $month = $from->copy()->addMonths($i);
+            $key = $month->format('Y-m');
+            $labels[] = $month->translatedFormat('M Y');
+            $values[] = (int) ($rows[$key] ?? 0);
+        }
+
+        return ['labels' => $labels, 'values' => $values];
+    }
+
+    public function breakdown(string $groupBy, string $metric = 'count', ?string $dateFrom = null, ?string $dateTo = null): array
+    {
+        if ($groupBy === 'month') {
+            return $this->monthlyTrend();
+        }
+
+        $query = CustomerComplaint::query();
+        $this->applyDateRange($query, $dateFrom, $dateTo);
+
+        if ($metric === 'avg_resolution_days') {
+            $query->whereNotNull('closed_at');
+        }
+
+        $column = $this->columnFor($groupBy);
+        $valueExpr = $metric === 'avg_resolution_days'
+            ? "AVG({$this->resolutionDaysExpression()})"
+            : 'COUNT(*)';
+
+        $rows = $query
+            ->selectRaw("{$column} as bucket, {$valueExpr} as value")
+            ->groupBy($column)
+            ->pluck('value', 'bucket');
+
+        $labels = [];
+        $values = [];
+
+        foreach ($rows as $bucket => $value) {
+            $labels[] = $this->labelFor($groupBy, $bucket);
+            $values[] = $metric === 'avg_resolution_days' ? round((float) $value, 1) : (int) $value;
+        }
+
+        return ['labels' => $labels, 'values' => $values];
+    }
+
+    /**
+     * Fractional days between received_date and closed_at, portable across Postgres (production) and SQLite (tests).
+     */
+    private function resolutionDaysExpression(): string
+    {
+        return match (DB::connection()->getDriverName()) {
+            'sqlite' => 'julianday(closed_at) - julianday(received_date)',
+            default => 'EXTRACT(EPOCH FROM (closed_at - received_date)) / 86400',
+        };
+    }
+
+    private function monthBucketExpression(string $column): string
+    {
+        return match (DB::connection()->getDriverName()) {
+            'sqlite' => "strftime('%Y-%m', {$column})",
+            default => "to_char({$column}, 'YYYY-MM')",
+        };
+    }
+
+    private function applyDateRange(Builder $query, ?string $dateFrom, ?string $dateTo): void
+    {
+        if ($dateFrom) {
+            $query->where('received_date', '>=', Carbon::parse($dateFrom));
+        }
+
+        if ($dateTo) {
+            $query->where('received_date', '<=', Carbon::parse($dateTo));
+        }
+    }
+
+    private function columnFor(string $groupBy): string
+    {
+        return match ($groupBy) {
+            'source_type' => 'complaint_source_type_id',
+            'subject' => 'complaint_subject_id',
+            'department' => 'department_id',
+            'distributor' => 'distributor_id',
+            'supplier' => 'supplier_id',
+            'severity' => 'severity',
+            'status' => 'status',
+            'channel' => 'channel',
+            default => throw new \InvalidArgumentException("Unsupported group_by [{$groupBy}]"),
+        };
+    }
+
+    private function labelFor(string $groupBy, mixed $bucket): string
+    {
+        if ($bucket === null || $bucket === '') {
+            return '-';
+        }
+
+        return match ($groupBy) {
+            'source_type' => ComplaintSourceType::find($bucket)?->name ?? '-',
+            'subject' => ComplaintSubject::find($bucket)?->name ?? '-',
+            'department' => Department::find($bucket)?->name ?? '-',
+            'distributor' => Distributor::find($bucket)?->name ?? '-',
+            'supplier' => Supplier::find($bucket)?->name ?? '-',
+            'severity' => self::SEVERITY_LABELS[$bucket] ?? $bucket,
+            'status' => CustomerComplaintStatus::from($bucket)->label(),
+            'channel' => ComplaintChannel::from($bucket)->label(),
+            default => (string) $bucket,
+        };
+    }
+}

--- a/database/migrations/2026_09_13_130000_create_customer_complaint_report_templates_table.php
+++ b/database/migrations/2026_09_13_130000_create_customer_complaint_report_templates_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('customer_complaint_report_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('created_by_id')->constrained('users')->cascadeOnDelete();
+            $table->boolean('is_shared')->default(false);
+            $table->json('config');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_complaint_report_templates');
+    }
+};

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -408,4 +408,9 @@ return [
         'deletedError' => 'This action type cannot be deleted because it has actions assigned to it.',
         'deletedErrorProtected' => 'This system-default action type cannot be deleted.'
     ],
+    'customerComplaintReportTemplate' => [
+        'created' => 'Report template created.',
+        'updated' => 'Report template updated.',
+        'deleted' => 'Report template deleted.'
+    ],
 ];

--- a/lang/tr/messages.php
+++ b/lang/tr/messages.php
@@ -409,4 +409,9 @@ return [
         'deletedError' => 'Bu aksiyon türü silinemez çünkü üzerinde kayıtlı aksiyonlar var.',
         'deletedErrorProtected' => 'Sistem varsayılanı olan bu aksiyon türü silinemez.'
     ],
+    'customerComplaintReportTemplate' => [
+        'created' => 'Rapor şablonu oluşturuldu.',
+        'updated' => 'Rapor şablonu güncellendi.',
+        'deleted' => 'Rapor şablonu silindi.'
+    ],
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,13 @@
                 "@vuelidate/core": "^2.0.3",
                 "@vuelidate/validators": "^2.0.4",
                 "@vueuse/core": "^10.9.0",
+                "chart.js": "^4.5.1",
                 "dayjs": "^1.11.10",
                 "floating-vue": "^5.2.2",
                 "pinia": "^3.0.3",
                 "pinia-plugin-persistedstate": "^4.5.0",
                 "tailwindcss": "^4.1.12",
+                "vue-chartjs": "^5.3.4",
                 "vue-i18n": "^9.11.0",
                 "vuedraggable": "^4.1.0",
                 "ziggy-js": "^2.6.3"
@@ -666,6 +668,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+            "license": "MIT"
         },
         "node_modules/@laravel/multiplex": {
             "version": "0.4.2",
@@ -3174,6 +3182,18 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chart.js": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+            "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+            "license": "MIT",
+            "dependencies": {
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=8"
             }
         },
         "node_modules/chokidar": {
@@ -8220,6 +8240,16 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vue-chartjs": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.4.tgz",
+            "integrity": "sha512-x3Fqob8RQvrTdssfi9ecsCzEkFOd8JPmNwSkSQzdfKj/uBsRJs/Y88cZcZIEcPsTVfMGwMo4MOoihoDG2DoE/g==",
+            "license": "MIT",
+            "peerDependencies": {
+                "chart.js": "^4.1.1",
+                "vue": "^3.0.0-0 || ^2.7.0"
             }
         },
         "node_modules/vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -51,11 +51,13 @@
         "@vuelidate/core": "^2.0.3",
         "@vuelidate/validators": "^2.0.4",
         "@vueuse/core": "^10.9.0",
+        "chart.js": "^4.5.1",
         "dayjs": "^1.11.10",
         "floating-vue": "^5.2.2",
         "pinia": "^3.0.3",
         "pinia-plugin-persistedstate": "^4.5.0",
         "tailwindcss": "^4.1.12",
+        "vue-chartjs": "^5.3.4",
         "vue-i18n": "^9.11.0",
         "vuedraggable": "^4.1.0",
         "ziggy-js": "^2.6.3"

--- a/resources/js/Components/Chart/ChartWidget.vue
+++ b/resources/js/Components/Chart/ChartWidget.vue
@@ -1,0 +1,68 @@
+<script setup>
+import {computed} from "vue";
+import {Chart as ChartJS, registerables} from "chart.js";
+import {Bar, Pie, Line} from "vue-chartjs";
+import Table from "@/Components/Table/Table.vue";
+
+ChartJS.register(...registerables);
+
+const props = defineProps({
+  chartType: {
+    type: String,
+    default: "bar",
+  },
+  labels: {
+    type: Array,
+    default: () => [],
+  },
+  values: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const palette = ["#f43f5e", "#6366f1", "#10b981", "#f59e0b", "#0ea5e9", "#a855f7", "#ec4899", "#14b8a6"];
+
+const chartData = computed(() => ({
+  labels: props.labels,
+  datasets: [
+    {
+      data: props.values,
+      backgroundColor: props.chartType === "pie"
+          ? props.labels.map((_, i) => palette[i % palette.length])
+          : palette[0],
+      borderColor: palette[0],
+      borderWidth: props.chartType === "line" ? 2 : 0,
+      tension: 0.3,
+    },
+  ],
+}));
+
+const chartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {display: props.chartType === "pie"},
+  },
+}));
+
+const tableRows = computed(() => props.labels.map((label, i) => ({label, value: props.values[i]})));
+const tableHeaders = [
+  {id: "label", label: "Etiket"},
+  {id: "value", label: "Değer"},
+];
+</script>
+
+<template>
+  <div class="h-64">
+    <div v-if="labels.length === 0" class="h-full flex items-center justify-center text-sm text-slate-400">
+      Veri yok
+    </div>
+    <Bar v-else-if="chartType === 'bar'" :data="chartData" :options="chartOptions"/>
+    <Pie v-else-if="chartType === 'pie'" :data="chartData" :options="chartOptions"/>
+    <Line v-else-if="chartType === 'line'" :data="chartData" :options="chartOptions"/>
+    <div v-else class="h-full overflow-y-auto">
+      <Table :data="tableRows" :headers="tableHeaders" :action-column="false"/>
+    </div>
+  </div>
+</template>

--- a/resources/js/Languages/en.json
+++ b/resources/js/Languages/en.json
@@ -230,6 +230,7 @@
         "customerComplaintManagement": "Customer Complaints",
         "customers": "Customers",
         "customerComplaints": "Complaints",
+        "customerComplaintAnalytics": "Analytics",
         "distributors": "Distributors",
         "standards": "Standards",
         "suppliers": "Suppliers",

--- a/resources/js/Languages/tr.json
+++ b/resources/js/Languages/tr.json
@@ -205,6 +205,7 @@
         "customerComplaintManagement": "Müşteri Şikayetleri",
         "customers": "Müşteriler",
         "customerComplaints": "Şikayetler",
+        "customerComplaintAnalytics": "Analiz",
         "distributors": "Dağıtıcılar",
         "standards": "Standartlar",
         "suppliers": "Tedarikçiler",

--- a/resources/js/Pages/Modules/CustomerComplaint/Analytics/IndexPage.vue
+++ b/resources/js/Pages/Modules/CustomerComplaint/Analytics/IndexPage.vue
@@ -1,0 +1,273 @@
+<script setup>
+import {ref} from "vue";
+import {useForm, router} from "@inertiajs/vue3";
+import AppLayout from "@/Layouts/AppLayout.vue";
+import Grid from "@/Layouts/Grid.vue";
+import DataWidget from "@/Layouts/DataWidget.vue";
+import SimpleButton from "@/Components/Button/SimpleButton.vue";
+import HelpButton from "@/Components/Help/HelpButton.vue";
+import Modal from "@/Components/Modal/Modal.vue";
+import Form from "@/Components/Form/Form.vue";
+import FormSection from "@/Components/Form/FormSection.vue";
+import InputGroup from "@/Components/Form/InputGroup.vue";
+import TextInput from "@/Components/Form/TextInput.vue";
+import SelectInput from "@/Components/Form/SelectInput.vue";
+import SwitchInput from "@/Components/Form/SwitchInput.vue";
+import ChartWidget from "@/Components/Chart/ChartWidget.vue";
+
+import Translates from "./translates";
+import {helpers, required} from "@vuelidate/validators";
+import {useVuelidate} from "@vuelidate/core";
+
+const {t, tm} = Translates();
+
+const props = defineProps({
+  summary: Object,
+  defaultBreakdowns: {
+    type: Array,
+    default: () => [],
+  },
+  templates: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const chartTypeOptions = [
+  {id: "bar", label: tm("term.chartTypeValue.bar")},
+  {id: "pie", label: tm("term.chartTypeValue.pie")},
+  {id: "line", label: tm("term.chartTypeValue.line")},
+  {id: "table", label: tm("term.chartTypeValue.table")},
+];
+
+const groupByOptions = [
+  {id: "source_type", label: tm("term.groupByValue.source_type")},
+  {id: "subject", label: tm("term.groupByValue.subject")},
+  {id: "severity", label: tm("term.groupByValue.severity")},
+  {id: "status", label: tm("term.groupByValue.status")},
+  {id: "channel", label: tm("term.groupByValue.channel")},
+  {id: "department", label: tm("term.groupByValue.department")},
+  {id: "distributor", label: tm("term.groupByValue.distributor")},
+  {id: "supplier", label: tm("term.groupByValue.supplier")},
+  {id: "month", label: tm("term.groupByValue.month")},
+];
+
+const metricOptions = [
+  {id: "count", label: tm("term.metricValue.count")},
+  {id: "avg_resolution_days", label: tm("term.metricValue.avg_resolution_days")},
+];
+
+/* Template Create/Update Form */
+const showModal = ref(false);
+const formType = ref("create");
+const form = useForm({
+  id: null,
+  name: "",
+  is_shared: false,
+  config: {
+    chart_type: "bar",
+    group_by: "source_type",
+    metric: "count",
+    date_from: "",
+    date_to: "",
+  },
+});
+
+const rules = ref({
+  name: {required: helpers.withMessage(t("message.validation.required"), required)},
+  config: {
+    chart_type: {required: helpers.withMessage(t("message.validation.required"), required)},
+    group_by: {required: helpers.withMessage(t("message.validation.required"), required)},
+    metric: {required: helpers.withMessage(t("message.validation.required"), required)},
+  },
+});
+const v$ = useVuelidate(rules, form);
+
+const openCreate = () => {
+  form.reset();
+  v$.value.$reset();
+  previewData.value = null;
+  formType.value = "create";
+  showModal.value = true;
+};
+
+const openEdit = (template) => {
+  form.id = template.id;
+  form.name = template.name;
+  form.is_shared = template.is_shared;
+  form.config = {
+    chart_type: template.config.chart_type,
+    group_by: template.config.group_by,
+    metric: template.config.metric,
+    date_from: template.config.date_from ?? "",
+    date_to: template.config.date_to ?? "",
+  };
+  previewData.value = template.data;
+  formType.value = "update";
+  showModal.value = true;
+};
+
+const handleSubmit = async () => {
+  const isValidated = await v$.value.$validate();
+  if (!isValidated) return;
+
+  if (formType.value === "create") {
+    form.post(route("customer-complaint-report-template.store"), {
+      onSuccess: () => {
+        form.reset();
+        v$.value.$reset();
+        showModal.value = false;
+      },
+    });
+  } else {
+    form.put(route("customer-complaint-report-template.update", {customerComplaintReportTemplate: form.id}), {
+      onSuccess: () => {
+        form.reset();
+        v$.value.$reset();
+        showModal.value = false;
+      },
+    });
+  }
+};
+
+const handleDelete = (id) => {
+  router.delete(route("customer-complaint-report-template.destroy", id), {
+    preserveState: true,
+  });
+};
+
+/* Live preview inside the modal */
+const previewData = ref(null);
+const previewLoading = ref(false);
+const runPreview = async () => {
+  previewLoading.value = true;
+  try {
+    const response = await window.axios.post(route("customer-complaint-analytics.preview"), {
+      group_by: form.config.group_by,
+      metric: form.config.metric,
+      date_from: form.config.date_from || null,
+      date_to: form.config.date_to || null,
+    });
+    previewData.value = response.data;
+  } finally {
+    previewLoading.value = false;
+  }
+};
+</script>
+
+<template>
+  <app-layout :title="tm('title.indexPage.title')" :sub-title="tm('title.indexPage.subTitle')">
+    <template #actionArea>
+      <help-button title="Şikayet Analizi — Nasıl Çalışır?" subtitle="Özet veriler ve özel rapor şablonları">
+        <p>Üstteki kartlar tüm şikayet verilerinden canlı hesaplanan özetlerdir (toplam, açık, ortalama çözüm süresi, süresi geçen).</p>
+        <p><strong>Genel Bakış</strong> bölümü sabit varsayılan grafiklerdir. <strong>Rapor Şablonlarım</strong> bölümünde ise kendi grafiğinizi (tip, gruplama, metrik, tarih aralığı) seçip kaydedebilir, isterseniz herkese açık paylaşabilirsiniz.</p>
+      </help-button>
+      <simple-button @click="openCreate" color="green">
+        <font-awesome-icon icon="plus" class="mr-2"/>
+        <span v-text="t('action.createTemplate')"/>
+      </simple-button>
+      <simple-button type="route" :link="route('customer-complaint.index')">
+        <font-awesome-icon icon="fa-solid fa-left-long" class="mr-2"/>
+        <span v-text="t('action.goBack')"/>
+      </simple-button>
+    </template>
+
+    <!--Summary Cards-->
+    <Grid :large="4" :medium="2" :small="1">
+      <data-widget :title="tm('term.totalComplaints')" :value="summary.total" bg-icon="comment-dots"/>
+      <data-widget :title="tm('term.openComplaints')" :value="summary.open" bg-icon="hourglass-half" diff-color="orange"/>
+      <data-widget
+          :title="tm('term.avgResolutionDays')"
+          :value="summary.avg_resolution_days !== null ? `${summary.avg_resolution_days} ${tm('term.days')}` : '-'"
+          bg-icon="arrow-trend-up"
+          diff-color="green"
+      />
+      <data-widget :title="tm('term.overdueComplaints')" :value="summary.overdue" bg-icon="circle-exclamation" diff-color="red"/>
+    </Grid>
+
+    <!--Default Breakdowns-->
+    <h3 class="mt-8 mb-3 font-semibold text-slate-700 dark:text-slate-200" v-text="tm('term.overview')"></h3>
+    <Grid :large="2" :medium="1" :small="1" :gap="4">
+      <div v-for="breakdown in defaultBreakdowns" :key="breakdown.title"
+           class="rounded-xl border border-slate-300 bg-white p-4 shadow-md shadow-slate-300/40 dark:border-slate-500 dark:bg-slate-700">
+        <p class="font-semibold mb-2" v-text="breakdown.title"></p>
+        <chart-widget :chart-type="breakdown.chart_type" :labels="breakdown.data.labels" :values="breakdown.data.values"/>
+      </div>
+    </Grid>
+
+    <!--User Templates-->
+    <h3 class="mt-8 mb-3 font-semibold text-slate-700 dark:text-slate-200" v-text="tm('term.myTemplates')"></h3>
+    <Grid v-if="templates.length > 0" :large="2" :medium="1" :small="1" :gap="4">
+      <div v-for="template in templates" :key="template.id"
+           class="rounded-xl border border-slate-300 bg-white p-4 shadow-md shadow-slate-300/40 dark:border-slate-500 dark:bg-slate-700">
+        <div class="flex items-center justify-between mb-2">
+          <div class="flex items-center gap-2">
+            <p class="font-semibold" v-text="template.name"></p>
+            <span v-if="template.is_shared" class="px-2 py-0.5 rounded text-xs bg-indigo-100 text-indigo-700" v-text="tm('term.sharedBadge')"></span>
+          </div>
+          <div v-if="template.can_manage" class="flex items-center gap-2 text-slate-500">
+            <font-awesome-icon icon="edit" class="cursor-pointer hover:text-sky-600" @click="openEdit(template)"/>
+            <font-awesome-icon icon="trash-can" class="cursor-pointer hover:text-rose-600" @click="handleDelete(template.id)"/>
+          </div>
+        </div>
+        <p class="text-xs text-slate-500 mb-2">{{ tm('term.createdBy') }}: {{ template.created_by?.name }}</p>
+        <chart-widget :chart-type="template.config.chart_type" :labels="template.data.labels" :values="template.data.values"/>
+      </div>
+    </Grid>
+    <p v-else class="text-sm text-slate-500" v-text="tm('message.feedback.emptyTemplatesList')"></p>
+
+    <teleport to="body">
+      <Modal
+          v-model="showModal"
+          :header="formType === 'create' ? tm('title.createTemplateModal.title') : tm('title.updateTemplateModal.title')"
+          :sub-header="formType === 'create' ? tm('title.createTemplateModal.subTitle') : tm('title.updateTemplateModal.subTitle')"
+          closeable
+          close-button
+          max-width="3xl"
+      >
+        <Form full-size>
+          <FormSection bg-less>
+            <input-group class="col-span-12" labelFor="name" :label="tm('term.templateName')" :errors="v$.name.$errors">
+              <text-input v-model="form.name"/>
+            </input-group>
+
+            <input-group class="col-span-4" labelFor="chart_type" :label="tm('term.chartType')">
+              <select-input v-model="form.config.chart_type" :options="chartTypeOptions"/>
+            </input-group>
+
+            <input-group class="col-span-4" labelFor="group_by" :label="tm('term.groupBy')">
+              <select-input v-model="form.config.group_by" :options="groupByOptions"/>
+            </input-group>
+
+            <input-group class="col-span-4" labelFor="metric" :label="tm('term.metric')">
+              <select-input v-model="form.config.metric" :options="metricOptions"/>
+            </input-group>
+
+            <input-group class="col-span-4" labelFor="date_from" :label="tm('term.dateFrom')">
+              <text-input v-model="form.config.date_from" input-type="date"/>
+            </input-group>
+
+            <input-group class="col-span-4" labelFor="date_to" :label="tm('term.dateTo')">
+              <text-input v-model="form.config.date_to" input-type="date"/>
+            </input-group>
+
+            <input-group class="col-span-4" labelFor="is_shared" :label="tm('term.isShared')">
+              <switch-input v-model="form.is_shared"/>
+            </input-group>
+          </FormSection>
+
+          <div class="px-4 pb-4">
+            <SimpleButton :label="t('action.preview')" color="blue" :loading="previewLoading" @click="runPreview"/>
+            <div v-if="previewData" class="mt-4 rounded-lg border border-slate-200 dark:border-slate-600 p-3">
+              <chart-widget :chart-type="form.config.chart_type" :labels="previewData.labels" :values="previewData.values"/>
+            </div>
+          </div>
+        </Form>
+        <template #footer>
+          <SimpleButton :label="t('action.reset')" color="orange" @click="form.reset()"/>
+          <SimpleButton :label="t(`action.${formType === 'create' ? 'create' : 'update'}`)" color="green" @click="handleSubmit" :loading="form.processing"/>
+        </template>
+      </Modal>
+    </teleport>
+  </app-layout>
+</template>

--- a/resources/js/Pages/Modules/CustomerComplaint/Analytics/translates.js
+++ b/resources/js/Pages/Modules/CustomerComplaint/Analytics/translates.js
@@ -1,0 +1,18 @@
+import {useI18n} from "vue-i18n";
+import tr from "./translates/tr.json"
+import en from "./translates/en.json"
+
+export default function () {
+    const {t, tm, tc} = useI18n({
+        messages: {
+            en,
+            tr
+        },
+    });
+
+    return {
+        t,
+        tm,
+        tc,
+    }
+}

--- a/resources/js/Pages/Modules/CustomerComplaint/Analytics/translates/en.json
+++ b/resources/js/Pages/Modules/CustomerComplaint/Analytics/translates/en.json
@@ -1,0 +1,64 @@
+{
+    "title": {
+        "indexPage": {
+            "title": "Complaint Analytics",
+            "subTitle": "Summary statistics from complaint data and your own saved report templates"
+        },
+        "createTemplateModal": {
+            "title": "Create Report Template",
+            "subTitle": "Pick a chart type, grouping and metric, then save it as a template"
+        },
+        "updateTemplateModal": {
+            "title": "Update Report Template",
+            "subTitle": "Update the template's configuration"
+        }
+    },
+    "term": {
+        "totalComplaints": "Total Complaints",
+        "openComplaints": "Open Complaints",
+        "avgResolutionDays": "Avg. Resolution Time",
+        "days": "days",
+        "overdueComplaints": "Overdue",
+        "overview": "Overview",
+        "myTemplates": "My Report Templates",
+        "templateName": "Template Name",
+        "chartType": "Chart Type",
+        "groupBy": "Group By",
+        "metric": "Metric",
+        "dateFrom": "Date From",
+        "dateTo": "Date To",
+        "isShared": "Shared with everyone",
+        "chartTypeValue": {
+            "bar": "Bar Chart",
+            "pie": "Pie Chart",
+            "line": "Line Chart",
+            "table": "Table"
+        },
+        "groupByValue": {
+            "source_type": "Complaint Source",
+            "subject": "Complaint Subject",
+            "severity": "Severity",
+            "status": "Status",
+            "channel": "Channel",
+            "department": "Department",
+            "distributor": "Distributor",
+            "supplier": "Supplier",
+            "month": "Month (Trend)"
+        },
+        "metricValue": {
+            "count": "Count",
+            "avg_resolution_days": "Average Resolution Time (days)"
+        },
+        "sharedBadge": "Shared",
+        "createdBy": "Created By"
+    },
+    "message": {
+        "feedback": {
+            "emptyTemplatesList": "No report templates have been created yet"
+        }
+    },
+    "action": {
+        "createTemplate": "Add New Template",
+        "preview": "Preview"
+    }
+}

--- a/resources/js/Pages/Modules/CustomerComplaint/Analytics/translates/tr.json
+++ b/resources/js/Pages/Modules/CustomerComplaint/Analytics/translates/tr.json
@@ -1,0 +1,64 @@
+{
+    "title": {
+        "indexPage": {
+            "title": "Şikayet Analizi",
+            "subTitle": "Şikayet verilerinden özet istatistikler ve kendi rapor şablonlarınızı oluşturun"
+        },
+        "createTemplateModal": {
+            "title": "Rapor Şablonu Oluştur",
+            "subTitle": "Grafik tipini, gruplama ve metriği seçip şablon olarak kaydedin"
+        },
+        "updateTemplateModal": {
+            "title": "Rapor Şablonunu Güncelle",
+            "subTitle": "Şablon yapılandırmasını güncelleyin"
+        }
+    },
+    "term": {
+        "totalComplaints": "Toplam Şikayet",
+        "openComplaints": "Açık Şikayet",
+        "avgResolutionDays": "Ort. Çözüm Süresi",
+        "days": "gün",
+        "overdueComplaints": "Süresi Geçen",
+        "overview": "Genel Bakış",
+        "myTemplates": "Rapor Şablonlarım",
+        "templateName": "Şablon Adı",
+        "chartType": "Grafik Tipi",
+        "groupBy": "Gruplama",
+        "metric": "Metrik",
+        "dateFrom": "Başlangıç Tarihi",
+        "dateTo": "Bitiş Tarihi",
+        "isShared": "Herkese Açık",
+        "chartTypeValue": {
+            "bar": "Çubuk Grafik",
+            "pie": "Pasta Grafik",
+            "line": "Çizgi Grafik",
+            "table": "Tablo"
+        },
+        "groupByValue": {
+            "source_type": "Şikayet Kaynağı",
+            "subject": "Şikayet Konusu",
+            "severity": "Önem Derecesi",
+            "status": "Durum",
+            "channel": "Kanal",
+            "department": "Departman",
+            "distributor": "Dağıtıcı",
+            "supplier": "Tedarikçi",
+            "month": "Ay (Trend)"
+        },
+        "metricValue": {
+            "count": "Adet",
+            "avg_resolution_days": "Ortalama Çözüm Süresi (gün)"
+        },
+        "sharedBadge": "Paylaşılan",
+        "createdBy": "Oluşturan"
+    },
+    "message": {
+        "feedback": {
+            "emptyTemplatesList": "Henüz hiç rapor şablonu oluşturulmamış"
+        }
+    },
+    "action": {
+        "createTemplate": "Yeni Şablon Ekle",
+        "preview": "Önizle"
+    }
+}

--- a/resources/js/Sources/mainMenu.js
+++ b/resources/js/Sources/mainMenu.js
@@ -194,6 +194,14 @@ export default function ({roles, permissions}) {
                         icon: 'handshake',
                         type: "route",
                         link: 'customer.index'
+                    },
+                    /*Analytics*/
+                    {
+                        id: 'cc-analytics',
+                        label: t('mainMenu.customerComplaintAnalytics'),
+                        icon: 'arrow-trend-up',
+                        type: "route",
+                        link: 'customer-complaint-analytics.index'
                     }
                 ]
             },

--- a/resources/js/actions/App/Http/Controllers/CustomerComplaintAnalyticsController.ts
+++ b/resources/js/actions/App/Http/Controllers/CustomerComplaintAnalyticsController.ts
@@ -1,0 +1,370 @@
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../wayfinder'
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index.url(options),
+    method: 'get',
+})
+
+index.definition = {
+    methods: ["get","head"],
+    url: '/customer-complaint/analytics',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+index.url = (options?: RouteQueryOptions) => {
+    return index.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+    const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+        indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+        indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index.form = indexForm
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::preview
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:66
+ * @route '/customer-complaint/analytics/preview'
+ */
+export const preview = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: preview.url(options),
+    method: 'post',
+})
+
+preview.definition = {
+    methods: ["post"],
+    url: '/customer-complaint/analytics/preview',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::preview
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:66
+ * @route '/customer-complaint/analytics/preview'
+ */
+preview.url = (options?: RouteQueryOptions) => {
+    return preview.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::preview
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:66
+ * @route '/customer-complaint/analytics/preview'
+ */
+preview.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: preview.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::preview
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:66
+ * @route '/customer-complaint/analytics/preview'
+ */
+    const previewForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: preview.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::preview
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:66
+ * @route '/customer-complaint/analytics/preview'
+ */
+        previewForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: preview.url(options),
+            method: 'post',
+        })
+    
+    preview.form = previewForm
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::store
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:83
+ * @route '/customer-complaint-report-template'
+ */
+export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store.url(options),
+    method: 'post',
+})
+
+store.definition = {
+    methods: ["post"],
+    url: '/customer-complaint-report-template',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::store
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:83
+ * @route '/customer-complaint-report-template'
+ */
+store.url = (options?: RouteQueryOptions) => {
+    return store.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::store
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:83
+ * @route '/customer-complaint-report-template'
+ */
+store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::store
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:83
+ * @route '/customer-complaint-report-template'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::store
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:83
+ * @route '/customer-complaint-report-template'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::update
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:95
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+export const update = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: update.url(args, options),
+    method: 'put',
+})
+
+update.definition = {
+    methods: ["put"],
+    url: '/customer-complaint-report-template/{customerComplaintReportTemplate}',
+} satisfies RouteDefinition<["put"]>
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::update
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:95
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+update.url = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { customerComplaintReportTemplate: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { customerComplaintReportTemplate: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    customerComplaintReportTemplate: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        customerComplaintReportTemplate: typeof args.customerComplaintReportTemplate === 'object'
+                ? args.customerComplaintReportTemplate.id
+                : args.customerComplaintReportTemplate,
+                }
+
+    return update.definition.url
+            .replace('{customerComplaintReportTemplate}', parsedArgs.customerComplaintReportTemplate.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::update
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:95
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+update.put = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: update.url(args, options),
+    method: 'put',
+})
+
+    /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::update
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:95
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+    const updateForm = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::update
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:95
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+        updateForm.put = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    update.form = updateForm
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::destroy
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:104
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+export const destroy = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy.url(args, options),
+    method: 'delete',
+})
+
+destroy.definition = {
+    methods: ["delete"],
+    url: '/customer-complaint-report-template/{customerComplaintReportTemplate}',
+} satisfies RouteDefinition<["delete"]>
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::destroy
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:104
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+destroy.url = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { customerComplaintReportTemplate: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { customerComplaintReportTemplate: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    customerComplaintReportTemplate: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        customerComplaintReportTemplate: typeof args.customerComplaintReportTemplate === 'object'
+                ? args.customerComplaintReportTemplate.id
+                : args.customerComplaintReportTemplate,
+                }
+
+    return destroy.definition.url
+            .replace('{customerComplaintReportTemplate}', parsedArgs.customerComplaintReportTemplate.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::destroy
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:104
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+destroy.delete = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy.url(args, options),
+    method: 'delete',
+})
+
+    /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::destroy
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:104
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+    const destroyForm = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroy.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::destroy
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:104
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+        destroyForm.delete = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroy.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    destroy.form = destroyForm
+const CustomerComplaintAnalyticsController = { index, preview, store, update, destroy }
+
+export default CustomerComplaintAnalyticsController

--- a/resources/js/actions/App/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.ts
+++ b/resources/js/actions/App/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.ts
@@ -281,7 +281,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-export const show = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+export const show = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
@@ -296,7 +296,7 @@ show.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-show.url = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+show.url = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_action_type: args }
     }
@@ -329,7 +329,7 @@ show.url = (args: { measurement_device_action_type: string | number | { id: stri
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-show.get = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+show.get = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
@@ -338,7 +338,7 @@ show.get = (args: { measurement_device_action_type: string | number | { id: stri
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-show.head = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+show.head = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
@@ -348,7 +348,7 @@ show.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-    const showForm = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+    const showForm = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
         action: show.url(args, options),
         method: 'get',
     })
@@ -358,7 +358,7 @@ show.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-        showForm.get = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        showForm.get = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: show.url(args, options),
             method: 'get',
         })
@@ -367,7 +367,7 @@ show.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-        showForm.head = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        showForm.head = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: show.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'HEAD',
@@ -383,7 +383,7 @@ show.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-export const edit = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+export const edit = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(args, options),
     method: 'get',
 })
@@ -398,7 +398,7 @@ edit.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-edit.url = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+edit.url = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_action_type: args }
     }
@@ -431,7 +431,7 @@ edit.url = (args: { measurement_device_action_type: string | number | { id: stri
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-edit.get = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+edit.get = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(args, options),
     method: 'get',
 })
@@ -440,7 +440,7 @@ edit.get = (args: { measurement_device_action_type: string | number | { id: stri
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-edit.head = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+edit.head = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: edit.url(args, options),
     method: 'head',
 })
@@ -450,7 +450,7 @@ edit.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-    const editForm = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+    const editForm = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
         action: edit.url(args, options),
         method: 'get',
     })
@@ -460,7 +460,7 @@ edit.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-        editForm.get = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        editForm.get = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: edit.url(args, options),
             method: 'get',
         })
@@ -469,7 +469,7 @@ edit.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-        editForm.head = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        editForm.head = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: edit.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'HEAD',
@@ -485,7 +485,7 @@ edit.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-export const update = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+export const update = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(args, options),
     method: 'put',
 })
@@ -500,7 +500,7 @@ update.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-update.url = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+update.url = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_action_type: args }
     }
@@ -533,7 +533,7 @@ update.url = (args: { measurement_device_action_type: string | number | { id: st
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-update.put = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+update.put = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(args, options),
     method: 'put',
 })
@@ -542,7 +542,7 @@ update.put = (args: { measurement_device_action_type: string | number | { id: st
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-update.patch = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+update.patch = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
     url: update.url(args, options),
     method: 'patch',
 })
@@ -552,7 +552,7 @@ update.patch = (args: { measurement_device_action_type: string | number | { id: 
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-    const updateForm = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+    const updateForm = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
         action: update.url(args, {
                     [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                         _method: 'PUT',
@@ -567,7 +567,7 @@ update.patch = (args: { measurement_device_action_type: string | number | { id: 
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-        updateForm.put = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        updateForm.put = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
             action: update.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'PUT',
@@ -581,7 +581,7 @@ update.patch = (args: { measurement_device_action_type: string | number | { id: 
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-        updateForm.patch = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        updateForm.patch = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
             action: update.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'PATCH',
@@ -597,7 +597,7 @@ update.patch = (args: { measurement_device_action_type: string | number | { id: 
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:63
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-export const destroy = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+export const destroy = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: destroy.url(args, options),
     method: 'delete',
 })
@@ -612,7 +612,7 @@ destroy.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:63
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-destroy.url = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+destroy.url = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_action_type: args }
     }
@@ -645,7 +645,7 @@ destroy.url = (args: { measurement_device_action_type: string | number | { id: s
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:63
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-destroy.delete = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+destroy.delete = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: destroy.url(args, options),
     method: 'delete',
 })
@@ -655,7 +655,7 @@ destroy.delete = (args: { measurement_device_action_type: string | number | { id
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:63
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-    const destroyForm = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+    const destroyForm = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
         action: destroy.url(args, {
                     [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                         _method: 'DELETE',
@@ -670,7 +670,7 @@ destroy.delete = (args: { measurement_device_action_type: string | number | { id
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:63
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-        destroyForm.delete = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        destroyForm.delete = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
             action: destroy.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'DELETE',

--- a/resources/js/actions/App/Http/Controllers/index.ts
+++ b/resources/js/actions/App/Http/Controllers/index.ts
@@ -3,6 +3,7 @@ import ApiTokenController from './ApiTokenController'
 import Setting from './Setting'
 import Tag from './Tag'
 import User from './User'
+import CustomerComplaintAnalyticsController from './CustomerComplaintAnalyticsController'
 import DepartmentController from './DepartmentController'
 import Warehouse from './Warehouse'
 import BusinessManagement from './BusinessManagement'
@@ -55,6 +56,7 @@ ApiTokenController: Object.assign(ApiTokenController, ApiTokenController),
 Setting: Object.assign(Setting, Setting),
 Tag: Object.assign(Tag, Tag),
 User: Object.assign(User, User),
+CustomerComplaintAnalyticsController: Object.assign(CustomerComplaintAnalyticsController, CustomerComplaintAnalyticsController),
 DepartmentController: Object.assign(DepartmentController, DepartmentController),
 Warehouse: Object.assign(Warehouse, Warehouse),
 BusinessManagement: Object.assign(BusinessManagement, BusinessManagement),

--- a/resources/js/routes/certificate/index.ts
+++ b/resources/js/routes/certificate/index.ts
@@ -1,6 +1,6 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/certificate'
  */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -14,7 +14,7 @@ index.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/certificate'
  */
 index.url = (options?: RouteQueryOptions) => {
@@ -22,7 +22,7 @@ index.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/certificate'
  */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -30,7 +30,7 @@ index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/certificate'
  */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -39,7 +39,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/certificate'
  */
     const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -48,7 +48,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/certificate'
  */
         indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -56,7 +56,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/certificate'
  */
         indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/resources/js/routes/consumable-material/index.ts
+++ b/resources/js/routes/consumable-material/index.ts
@@ -1,6 +1,6 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/consumable-material'
  */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -14,7 +14,7 @@ index.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/consumable-material'
  */
 index.url = (options?: RouteQueryOptions) => {
@@ -22,7 +22,7 @@ index.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/consumable-material'
  */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -30,7 +30,7 @@ index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/consumable-material'
  */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -39,7 +39,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/consumable-material'
  */
     const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -48,7 +48,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/consumable-material'
  */
         indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -56,7 +56,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/consumable-material'
  */
         indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/resources/js/routes/customer-complaint-analytics/index.ts
+++ b/resources/js/routes/customer-complaint-analytics/index.ts
@@ -1,0 +1,140 @@
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index.url(options),
+    method: 'get',
+})
+
+index.definition = {
+    methods: ["get","head"],
+    url: '/customer-complaint/analytics',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+index.url = (options?: RouteQueryOptions) => {
+    return index.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+    const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+        indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::index
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:15
+ * @route '/customer-complaint/analytics'
+ */
+        indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index.form = indexForm
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::preview
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:66
+ * @route '/customer-complaint/analytics/preview'
+ */
+export const preview = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: preview.url(options),
+    method: 'post',
+})
+
+preview.definition = {
+    methods: ["post"],
+    url: '/customer-complaint/analytics/preview',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::preview
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:66
+ * @route '/customer-complaint/analytics/preview'
+ */
+preview.url = (options?: RouteQueryOptions) => {
+    return preview.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::preview
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:66
+ * @route '/customer-complaint/analytics/preview'
+ */
+preview.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: preview.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::preview
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:66
+ * @route '/customer-complaint/analytics/preview'
+ */
+    const previewForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: preview.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::preview
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:66
+ * @route '/customer-complaint/analytics/preview'
+ */
+        previewForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: preview.url(options),
+            method: 'post',
+        })
+    
+    preview.form = previewForm
+const customerComplaintAnalytics = {
+    index: Object.assign(index, index),
+preview: Object.assign(preview, preview),
+}
+
+export default customerComplaintAnalytics

--- a/resources/js/routes/customer-complaint-report-template/index.ts
+++ b/resources/js/routes/customer-complaint-report-template/index.ts
@@ -1,0 +1,241 @@
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../wayfinder'
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::store
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:83
+ * @route '/customer-complaint-report-template'
+ */
+export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store.url(options),
+    method: 'post',
+})
+
+store.definition = {
+    methods: ["post"],
+    url: '/customer-complaint-report-template',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::store
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:83
+ * @route '/customer-complaint-report-template'
+ */
+store.url = (options?: RouteQueryOptions) => {
+    return store.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::store
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:83
+ * @route '/customer-complaint-report-template'
+ */
+store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::store
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:83
+ * @route '/customer-complaint-report-template'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::store
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:83
+ * @route '/customer-complaint-report-template'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::update
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:95
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+export const update = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: update.url(args, options),
+    method: 'put',
+})
+
+update.definition = {
+    methods: ["put"],
+    url: '/customer-complaint-report-template/{customerComplaintReportTemplate}',
+} satisfies RouteDefinition<["put"]>
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::update
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:95
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+update.url = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { customerComplaintReportTemplate: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { customerComplaintReportTemplate: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    customerComplaintReportTemplate: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        customerComplaintReportTemplate: typeof args.customerComplaintReportTemplate === 'object'
+                ? args.customerComplaintReportTemplate.id
+                : args.customerComplaintReportTemplate,
+                }
+
+    return update.definition.url
+            .replace('{customerComplaintReportTemplate}', parsedArgs.customerComplaintReportTemplate.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::update
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:95
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+update.put = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: update.url(args, options),
+    method: 'put',
+})
+
+    /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::update
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:95
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+    const updateForm = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::update
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:95
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+        updateForm.put = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    update.form = updateForm
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::destroy
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:104
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+export const destroy = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy.url(args, options),
+    method: 'delete',
+})
+
+destroy.definition = {
+    methods: ["delete"],
+    url: '/customer-complaint-report-template/{customerComplaintReportTemplate}',
+} satisfies RouteDefinition<["delete"]>
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::destroy
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:104
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+destroy.url = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { customerComplaintReportTemplate: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { customerComplaintReportTemplate: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    customerComplaintReportTemplate: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        customerComplaintReportTemplate: typeof args.customerComplaintReportTemplate === 'object'
+                ? args.customerComplaintReportTemplate.id
+                : args.customerComplaintReportTemplate,
+                }
+
+    return destroy.definition.url
+            .replace('{customerComplaintReportTemplate}', parsedArgs.customerComplaintReportTemplate.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::destroy
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:104
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+destroy.delete = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy.url(args, options),
+    method: 'delete',
+})
+
+    /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::destroy
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:104
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+    const destroyForm = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroy.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\CustomerComplaintAnalyticsController::destroy
+ * @see app/Http/Controllers/CustomerComplaintAnalyticsController.php:104
+ * @route '/customer-complaint-report-template/{customerComplaintReportTemplate}'
+ */
+        destroyForm.delete = (args: { customerComplaintReportTemplate: string | number | { id: string | number } } | [customerComplaintReportTemplate: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroy.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    destroy.form = destroyForm
+const customerComplaintReportTemplate = {
+    store: Object.assign(store, store),
+update: Object.assign(update, update),
+destroy: Object.assign(destroy, destroy),
+}
+
+export default customerComplaintReportTemplate

--- a/resources/js/routes/device/index.ts
+++ b/resources/js/routes/device/index.ts
@@ -1,6 +1,6 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/device'
  */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -14,7 +14,7 @@ index.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/device'
  */
 index.url = (options?: RouteQueryOptions) => {
@@ -22,7 +22,7 @@ index.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/device'
  */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -30,7 +30,7 @@ index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/device'
  */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -39,7 +39,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/device'
  */
     const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -48,7 +48,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/device'
  */
         indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -56,7 +56,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/device'
  */
         indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/resources/js/routes/improvement-work/index.ts
+++ b/resources/js/routes/improvement-work/index.ts
@@ -1,6 +1,6 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/improvement-work'
  */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -14,7 +14,7 @@ index.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/improvement-work'
  */
 index.url = (options?: RouteQueryOptions) => {
@@ -22,7 +22,7 @@ index.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/improvement-work'
  */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -30,7 +30,7 @@ index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/improvement-work'
  */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -39,7 +39,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/improvement-work'
  */
     const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -48,7 +48,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/improvement-work'
  */
         indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -56,7 +56,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/improvement-work'
  */
         indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/resources/js/routes/index.ts
+++ b/resources/js/routes/index.ts
@@ -211,7 +211,7 @@ register.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     
     register.form = registerForm
 /**
- * @see routes/web.php:126
+ * @see routes/web.php:127
  * @route '/dashboard'
  */
 export const dashboard = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -225,7 +225,7 @@ dashboard.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:126
+ * @see routes/web.php:127
  * @route '/dashboard'
  */
 dashboard.url = (options?: RouteQueryOptions) => {
@@ -233,7 +233,7 @@ dashboard.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:126
+ * @see routes/web.php:127
  * @route '/dashboard'
  */
 dashboard.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -241,7 +241,7 @@ dashboard.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:126
+ * @see routes/web.php:127
  * @route '/dashboard'
  */
 dashboard.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -250,7 +250,7 @@ dashboard.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:126
+ * @see routes/web.php:127
  * @route '/dashboard'
  */
     const dashboardForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -259,7 +259,7 @@ dashboard.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:126
+ * @see routes/web.php:127
  * @route '/dashboard'
  */
         dashboardForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -267,7 +267,7 @@ dashboard.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:126
+ * @see routes/web.php:127
  * @route '/dashboard'
  */
         dashboardForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -282,7 +282,7 @@ dashboard.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     
     dashboard.form = dashboardForm
 /**
- * @see routes/web.php:376
+ * @see routes/web.php:388
  * @route '/test'
  */
 export const route = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -296,7 +296,7 @@ route.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:376
+ * @see routes/web.php:388
  * @route '/test'
  */
 route.url = (options?: RouteQueryOptions) => {
@@ -304,7 +304,7 @@ route.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:376
+ * @see routes/web.php:388
  * @route '/test'
  */
 route.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -312,7 +312,7 @@ route.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:376
+ * @see routes/web.php:388
  * @route '/test'
  */
 route.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -321,7 +321,7 @@ route.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:376
+ * @see routes/web.php:388
  * @route '/test'
  */
     const routeForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -330,7 +330,7 @@ route.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:376
+ * @see routes/web.php:388
  * @route '/test'
  */
         routeForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -338,7 +338,7 @@ route.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:376
+ * @see routes/web.php:388
  * @route '/test'
  */
         routeForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/resources/js/routes/machine/index.ts
+++ b/resources/js/routes/machine/index.ts
@@ -1,6 +1,6 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/machine'
  */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -14,7 +14,7 @@ index.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/machine'
  */
 index.url = (options?: RouteQueryOptions) => {
@@ -22,7 +22,7 @@ index.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/machine'
  */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -30,7 +30,7 @@ index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/machine'
  */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -39,7 +39,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/machine'
  */
     const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -48,7 +48,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/machine'
  */
         indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -56,7 +56,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/machine'
  */
         indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/resources/js/routes/measurement-device-action-type/index.ts
+++ b/resources/js/routes/measurement-device-action-type/index.ts
@@ -270,7 +270,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-export const show = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+export const show = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
@@ -285,7 +285,7 @@ show.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-show.url = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+show.url = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_action_type: args }
     }
@@ -318,7 +318,7 @@ show.url = (args: { measurement_device_action_type: string | number | { id: stri
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-show.get = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+show.get = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
@@ -327,7 +327,7 @@ show.get = (args: { measurement_device_action_type: string | number | { id: stri
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-show.head = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+show.head = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
@@ -337,7 +337,7 @@ show.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-    const showForm = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+    const showForm = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
         action: show.url(args, options),
         method: 'get',
     })
@@ -347,7 +347,7 @@ show.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-        showForm.get = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        showForm.get = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: show.url(args, options),
             method: 'get',
         })
@@ -356,7 +356,7 @@ show.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:44
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-        showForm.head = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        showForm.head = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: show.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'HEAD',
@@ -372,7 +372,7 @@ show.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-export const edit = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+export const edit = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(args, options),
     method: 'get',
 })
@@ -387,7 +387,7 @@ edit.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-edit.url = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+edit.url = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_action_type: args }
     }
@@ -420,7 +420,7 @@ edit.url = (args: { measurement_device_action_type: string | number | { id: stri
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-edit.get = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+edit.get = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(args, options),
     method: 'get',
 })
@@ -429,7 +429,7 @@ edit.get = (args: { measurement_device_action_type: string | number | { id: stri
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-edit.head = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+edit.head = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: edit.url(args, options),
     method: 'head',
 })
@@ -439,7 +439,7 @@ edit.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-    const editForm = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+    const editForm = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
         action: edit.url(args, options),
         method: 'get',
     })
@@ -449,7 +449,7 @@ edit.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-        editForm.get = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        editForm.get = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: edit.url(args, options),
             method: 'get',
         })
@@ -458,7 +458,7 @@ edit.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:49
  * @route '/measurement-device-action-type/{measurement_device_action_type}/edit'
  */
-        editForm.head = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        editForm.head = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
             action: edit.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'HEAD',
@@ -474,7 +474,7 @@ edit.head = (args: { measurement_device_action_type: string | number | { id: str
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-export const update = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+export const update = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(args, options),
     method: 'put',
 })
@@ -489,7 +489,7 @@ update.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-update.url = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+update.url = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_action_type: args }
     }
@@ -522,7 +522,7 @@ update.url = (args: { measurement_device_action_type: string | number | { id: st
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-update.put = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+update.put = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(args, options),
     method: 'put',
 })
@@ -531,7 +531,7 @@ update.put = (args: { measurement_device_action_type: string | number | { id: st
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-update.patch = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+update.patch = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
     url: update.url(args, options),
     method: 'patch',
 })
@@ -541,7 +541,7 @@ update.patch = (args: { measurement_device_action_type: string | number | { id: 
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-    const updateForm = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+    const updateForm = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
         action: update.url(args, {
                     [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                         _method: 'PUT',
@@ -556,7 +556,7 @@ update.patch = (args: { measurement_device_action_type: string | number | { id: 
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-        updateForm.put = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        updateForm.put = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
             action: update.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'PUT',
@@ -570,7 +570,7 @@ update.patch = (args: { measurement_device_action_type: string | number | { id: 
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:54
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-        updateForm.patch = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        updateForm.patch = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
             action: update.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'PATCH',
@@ -586,7 +586,7 @@ update.patch = (args: { measurement_device_action_type: string | number | { id: 
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:63
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-export const destroy = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+export const destroy = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: destroy.url(args, options),
     method: 'delete',
 })
@@ -601,7 +601,7 @@ destroy.definition = {
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:63
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-destroy.url = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+destroy.url = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { measurement_device_action_type: args }
     }
@@ -634,7 +634,7 @@ destroy.url = (args: { measurement_device_action_type: string | number | { id: s
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:63
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-destroy.delete = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+destroy.delete = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: destroy.url(args, options),
     method: 'delete',
 })
@@ -644,7 +644,7 @@ destroy.delete = (args: { measurement_device_action_type: string | number | { id
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:63
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-    const destroyForm = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+    const destroyForm = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
         action: destroy.url(args, {
                     [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                         _method: 'DELETE',
@@ -659,7 +659,7 @@ destroy.delete = (args: { measurement_device_action_type: string | number | { id
  * @see app/Http/Controllers/MeasurementDevice/Action/MeasurementDeviceActionTypeController.php:63
  * @route '/measurement-device-action-type/{measurement_device_action_type}'
  */
-        destroyForm.delete = (args: { measurement_device_action_type: string | number | { id: string | number } } | [measurement_device_action_type: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        destroyForm.delete = (args: { measurement_device_action_type: number | { id: number } } | [measurement_device_action_type: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
             action: destroy.url(args, {
                         [options?.mergeQuery ? 'mergeQuery' : 'query']: {
                             _method: 'DELETE',

--- a/resources/js/routes/product-tree/index.ts
+++ b/resources/js/routes/product-tree/index.ts
@@ -1,6 +1,6 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product-tree'
  */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -14,7 +14,7 @@ index.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product-tree'
  */
 index.url = (options?: RouteQueryOptions) => {
@@ -22,7 +22,7 @@ index.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product-tree'
  */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -30,7 +30,7 @@ index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product-tree'
  */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -39,7 +39,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product-tree'
  */
     const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -48,7 +48,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product-tree'
  */
         indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -56,7 +56,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product-tree'
  */
         indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/resources/js/routes/product/index.ts
+++ b/resources/js/routes/product/index.ts
@@ -1,6 +1,6 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product'
  */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -14,7 +14,7 @@ index.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product'
  */
 index.url = (options?: RouteQueryOptions) => {
@@ -22,7 +22,7 @@ index.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product'
  */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -30,7 +30,7 @@ index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product'
  */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -39,7 +39,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product'
  */
     const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -48,7 +48,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product'
  */
         indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -56,7 +56,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/product'
  */
         indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/resources/js/routes/raw-material/index.ts
+++ b/resources/js/routes/raw-material/index.ts
@@ -1,6 +1,6 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/raw-material'
  */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -14,7 +14,7 @@ index.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/raw-material'
  */
 index.url = (options?: RouteQueryOptions) => {
@@ -22,7 +22,7 @@ index.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/raw-material'
  */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -30,7 +30,7 @@ index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/raw-material'
  */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -39,7 +39,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/raw-material'
  */
     const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -48,7 +48,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/raw-material'
  */
         indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -56,7 +56,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/raw-material'
  */
         indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/resources/js/routes/take-time-off/index.ts
+++ b/resources/js/routes/take-time-off/index.ts
@@ -1,6 +1,6 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/take-time-off'
  */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -14,7 +14,7 @@ index.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/take-time-off'
  */
 index.url = (options?: RouteQueryOptions) => {
@@ -22,7 +22,7 @@ index.url = (options?: RouteQueryOptions) => {
 }
 
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/take-time-off'
  */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
@@ -30,7 +30,7 @@ index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     method: 'get',
 })
 /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/take-time-off'
  */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
@@ -39,7 +39,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 })
 
     /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/take-time-off'
  */
     const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -48,7 +48,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     })
 
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/take-time-off'
  */
         indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
@@ -56,7 +56,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
             method: 'get',
         })
             /**
- * @see routes/web.php:212
+ * @see routes/web.php:219
  * @route '/take-time-off'
  */
         indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,7 @@ use App\Http\Controllers\CapaWorkflowController;
 use App\Http\Controllers\CompanyAccreditationController;
 use App\Http\Controllers\ComplaintSourceTypeController;
 use App\Http\Controllers\ComplaintSubjectController;
+use App\Http\Controllers\CustomerComplaintAnalyticsController;
 use App\Http\Controllers\CustomerComplaintController;
 use App\Http\Controllers\CustomerComplaintSettingController;
 use App\Http\Controllers\CustomerComplaintWorkflowController;
@@ -196,6 +197,12 @@ Route::middleware([
         ['uri' => 'distributor', 'model' => 'distributor', 'controller' => DistributorController::class],
     ];
 
+    // Registered before the $mRoutes resource loop below: the customer-complaint resource's
+    // `GET customer-complaint/{customerComplaint}` show route would otherwise match "analytics"
+    // as the id parameter first (both are 2-segment GET routes), 404ing on model binding.
+    Route::get('customer-complaint/analytics', [CustomerComplaintAnalyticsController::class, 'index'])->name('customer-complaint-analytics.index');
+    Route::post('customer-complaint/analytics/preview', [CustomerComplaintAnalyticsController::class, 'preview'])->name('customer-complaint-analytics.preview');
+
     $plannedModules = [
         'product-tree',
         'improvement-work',
@@ -353,6 +360,11 @@ Route::middleware([
     Route::post('customer-complaint/{customerComplaint}/resolve', [CustomerComplaintWorkflowController::class, 'resolve'])->name('customer-complaint.resolve');
     Route::post('customer-complaint/{customerComplaint}/close', [CustomerComplaintWorkflowController::class, 'close'])->name('customer-complaint.close');
     Route::post('customer-complaint/{customerComplaint}/reopen', [CustomerComplaintWorkflowController::class, 'reopen'])->name('customer-complaint.reopen');
+
+    // Customer Complaint Report Templates (saved user-defined chart configs)
+    Route::post('customer-complaint-report-template', [CustomerComplaintAnalyticsController::class, 'store'])->name('customer-complaint-report-template.store');
+    Route::put('customer-complaint-report-template/{customerComplaintReportTemplate}', [CustomerComplaintAnalyticsController::class, 'update'])->name('customer-complaint-report-template.update');
+    Route::delete('customer-complaint-report-template/{customerComplaintReportTemplate}', [CustomerComplaintAnalyticsController::class, 'destroy'])->name('customer-complaint-report-template.destroy');
 
     /* Warehouse Setting Pages */
     Route::resource('warehouse-type', WarehouseTypeController::class);

--- a/tests/Feature/CustomerComplaintAnalyticsControllerTest.php
+++ b/tests/Feature/CustomerComplaintAnalyticsControllerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+use App\Models\Customer;
+use App\Models\CustomerComplaintReportTemplate;
+use App\Models\User;
+use App\Services\CustomerComplaint\CustomerComplaintWorkflowService;
+use Inertia\Testing\AssertableInertia as Assert;
+
+function makeAnalyticsComplaint(User $author, array $overrides = [])
+{
+    $customer = Customer::create(['name' => 'Analitik Test Müşterisi']);
+
+    $complaint = app(CustomerComplaintWorkflowService::class)->create([
+        'complaint_source_type_id' => complaintSourceTypeId('customer'),
+        'complaint_subject_id' => complaintSubjectId('other'),
+        'customer_id' => $customer->id,
+        'title' => 'Analitik test şikayeti',
+        'description' => 'Açıklama',
+        'channel' => 'portal',
+        'severity' => 'high',
+        'received_date' => now()->toDateString(),
+    ], $author);
+
+    if ($overrides !== []) {
+        $complaint->update($overrides);
+    }
+
+    return $complaint->fresh();
+}
+
+test('analytics page renders with summary, default breakdowns and templates', function () {
+    $user = User::factory()->create();
+    makeAnalyticsComplaint($user);
+
+    $this->actingAs($user)
+        ->get(route('customer-complaint-analytics.index'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('Modules/CustomerComplaint/Analytics/IndexPage')
+            ->has('summary.total')
+            ->has('defaultBreakdowns', 4)
+            ->has('templates')
+        );
+});
+
+test('summary counts overdue complaints whose response is past due and still open', function () {
+    $user = User::factory()->create();
+    makeAnalyticsComplaint($user, ['response_due_date' => now()->subDay()->toDateString()]);
+    makeAnalyticsComplaint($user, ['response_due_date' => now()->addDay()->toDateString()]);
+
+    $response = $this->actingAs($user)->get(route('customer-complaint-analytics.index'));
+
+    $response->assertInertia(fn (Assert $page) => $page->where('summary.overdue', 1));
+});
+
+test('summary computes average resolution days from closed complaints', function () {
+    $user = User::factory()->create();
+    $receivedMoment = now()->startOfDay()->subDays(4);
+    makeAnalyticsComplaint($user, [
+        'status' => 'closed',
+        'received_date' => $receivedMoment->toDateString(),
+        'closed_at' => $receivedMoment->copy()->addDays(3),
+    ]);
+    makeAnalyticsComplaint($user, [
+        'status' => 'closed',
+        'received_date' => $receivedMoment->toDateString(),
+        'closed_at' => $receivedMoment->copy()->addDays(4),
+    ]);
+
+    $response = $this->actingAs($user)->get(route('customer-complaint-analytics.index'));
+
+    $response->assertInertia(fn (Assert $page) => $page->where('summary.avg_resolution_days', 3.5));
+});
+
+test('preview endpoint returns aggregated labels and values for a valid config', function () {
+    $user = User::factory()->create();
+    makeAnalyticsComplaint($user, ['severity' => 'high']);
+
+    $this->actingAs($user)
+        ->postJson(route('customer-complaint-analytics.preview'), [
+            'group_by' => 'severity',
+            'metric' => 'count',
+        ])
+        ->assertOk()
+        ->assertJsonStructure(['labels', 'values']);
+});
+
+test('preview rejects an unsupported group_by value', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('customer-complaint-analytics.preview'), [
+            'group_by' => 'not_a_real_dimension',
+            'metric' => 'count',
+        ])
+        ->assertJsonValidationErrors('group_by');
+});
+
+test('a user can save a report template', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('customer-complaint-report-template.store'), [
+            'name' => 'Konuya Göre Dağılım',
+            'config' => [
+                'chart_type' => 'bar',
+                'group_by' => 'subject',
+                'metric' => 'count',
+            ],
+        ])
+        ->assertSessionHasNoErrors();
+
+    $template = CustomerComplaintReportTemplate::first();
+
+    expect($template->name)->toBe('Konuya Göre Dağılım')
+        ->and($template->created_by_id)->toBe($user->id)
+        ->and($template->is_shared)->toBeFalse();
+});
+
+test('saving a template rejects an invalid chart_type', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('customer-complaint-report-template.store'), [
+            'name' => 'Geçersiz Şablon',
+            'config' => [
+                'chart_type' => 'not_a_chart',
+                'group_by' => 'subject',
+                'metric' => 'count',
+            ],
+        ])
+        ->assertSessionHasErrors('config.chart_type');
+});
+
+test('a user cannot update another user\'s report template', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+    $template = CustomerComplaintReportTemplate::create([
+        'name' => 'Sahibine Özel',
+        'created_by_id' => $owner->id,
+        'config' => ['chart_type' => 'bar', 'group_by' => 'severity', 'metric' => 'count'],
+    ]);
+
+    $this->actingAs($other)
+        ->put(route('customer-complaint-report-template.update', $template), [
+            'name' => 'Değiştirildi',
+            'config' => ['chart_type' => 'pie', 'group_by' => 'status', 'metric' => 'count'],
+        ])
+        ->assertForbidden();
+});
+
+test('a user cannot delete another user\'s report template', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+    $template = CustomerComplaintReportTemplate::create([
+        'name' => 'Sahibine Özel',
+        'created_by_id' => $owner->id,
+        'config' => ['chart_type' => 'bar', 'group_by' => 'severity', 'metric' => 'count'],
+    ]);
+
+    $this->actingAs($other)
+        ->delete(route('customer-complaint-report-template.destroy', $template))
+        ->assertForbidden();
+
+    expect(CustomerComplaintReportTemplate::find($template->id))->not->toBeNull();
+});
+
+test('the owner can delete their own report template', function () {
+    $user = User::factory()->create();
+    $template = CustomerComplaintReportTemplate::create([
+        'name' => 'Silinecek Şablon',
+        'created_by_id' => $user->id,
+        'config' => ['chart_type' => 'bar', 'group_by' => 'severity', 'metric' => 'count'],
+    ]);
+
+    $this->actingAs($user)
+        ->delete(route('customer-complaint-report-template.destroy', $template))
+        ->assertSessionHasNoErrors();
+
+    expect(CustomerComplaintReportTemplate::find($template->id))->toBeNull();
+});


### PR DESCRIPTION
## Özet
- Şikayet verilerinden canlı hesaplanan özet dashboard: toplam/açık şikayet, ortalama çözüm süresi, süresi geçen şikayet + kaynak/önem derecesi/durum dağılımı ve aylık trend grafikleri.
- Kullanıcılar kendi grafik yapılandırmalarını (tip, gruplama, metrik, tarih aralığı) seçip "Rapor Şablonu" olarak kaydedebilir, isteğe bağlı herkese açık paylaşabilir. Kaydetmeden önce canlı önizleme.
- Chart.js + vue-chartjs projeye ilk kez eklendi (önceden hiç grafik kütüphanesi yoktu).
- `customer_complaint_report_templates` tablosu tek bir JSON `config` sütunu kullanır — kombinasyon sayısı sabit kolonlarla modellemek için fazla değişken.
- Aggregation SQL'i Postgres (üretim) ve SQLite (test) arasında sürücü-bağımsız (EXTRACT/to_char yerine julianday/strftime).

## Test planı
- [x] 10 yeni Pest testi, tüm suite 393/393 yeşil
- [x] Tarayıcıda uçtan uca doğrulandı: dashboard render, şablon oluştur → önizle → kaydet → sil

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9BJQ7qThdVE2PJikQwc1P